### PR TITLE
✨ feat: Add new slash commands for problem lookup and historical daily challenges

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -234,6 +234,30 @@ async def reload(ctx, extension):
         await ctx.send(f"Error reloading `{extension}`: {e}")
         bot.logger.error(f"Error reloading extension cogs.{extension}: {e}", exc_info=True)
 
+
+@bot.event
+async def on_ready():
+    """Called when the bot is ready"""
+    bot.logger.info(f"Bot logged in as {bot.user} (ID: {bot.user.id})")
+    bot.logger.info(f"Discord.py version: {discord.__version__}")
+    bot.logger.info(f"Connected to {len(bot.guilds)} guilds")
+    
+    # Initialize schedules
+    schedule_cog = bot.get_cog("ScheduleManagerCog")
+    if schedule_cog:
+        await schedule_cog.initialize_schedules()
+    else:
+        bot.logger.warning("ScheduleManagerCog not found during bot startup")
+    
+    # Auto-sync commands on startup (optional, comment out if not needed)
+    try:
+        synced = await bot.tree.sync()
+        bot.logger.info(f"Auto-synced {len(synced)} slash commands on startup")
+    except Exception as e:
+        bot.logger.error(f"Failed to auto-sync commands on startup: {e}")
+    
+    bot.logger.info("Bot is ready and operational!")
+
 async def load_extensions():
     if not os.path.exists("./cogs"):
         os.makedirs("./cogs")

--- a/cogs/schedule_manager_cog.py
+++ b/cogs/schedule_manager_cog.py
@@ -160,7 +160,7 @@ class ScheduleManagerCog(commands.Cog):
             await self.initialize_schedules()
             self.logger.info("All server daily challenges have been rescheduled")
 
-    async def create_problem_embed(self, problem_info: dict, domain: str = "com", is_daily: bool = False):
+    async def create_problem_embed(self, problem_info: dict, domain: str = "com", is_daily: bool = False, date_str: str = None):
         """Create an embed for a LeetCode problem"""
         color_map = {'Easy': 0x00FF00, 'Medium': 0xFFA500, 'Hard': 0xFF0000}
         emoji_map = {'Easy': '🟢', 'Medium': '🟡', 'Hard': '🔴'}
@@ -204,7 +204,9 @@ class ScheduleManagerCog(commands.Cog):
                 embed.add_field(name="🔍 Similar Questions", value="\n".join(similar_q_list), inline=False)
 
         if is_daily:
-            embed.set_footer(text=f"LeetCode Daily Challenge | {problem_info.get('date', 'Today')}", icon_url="https://leetcode.com/static/images/LeetCode_logo.png")
+            # Use passed date_str or fallback to problem_info date or 'Today'
+            display_date = date_str or problem_info.get('date', 'Today')
+            embed.set_footer(text=f"LeetCode Daily Challenge | {display_date}", icon_url="https://leetcode.com/static/images/LeetCode_logo.png")
         else:
             embed.set_footer(text="LeetCode Problem", icon_url="https://leetcode.com/static/images/LeetCode_logo.png")
 

--- a/cogs/schedule_manager_cog.py
+++ b/cogs/schedule_manager_cog.py
@@ -160,6 +160,81 @@ class ScheduleManagerCog(commands.Cog):
             await self.initialize_schedules()
             self.logger.info("All server daily challenges have been rescheduled")
 
+    async def create_problem_embed(self, problem_info: dict, domain: str = "com", is_daily: bool = False):
+        """Create an embed for a LeetCode problem"""
+        color_map = {'Easy': 0x00FF00, 'Medium': 0xFFA500, 'Hard': 0xFF0000}
+        emoji_map = {'Easy': '🟢', 'Medium': '🟡', 'Hard': '🔴'}
+        embed_color = color_map.get(problem_info['difficulty'], 0x0099FF)
+
+        embed = discord.Embed(
+            title=f"🔗 {problem_info['id']}. {problem_info['title']}",
+            color=embed_color,
+            url=problem_info['link']
+        )
+
+        if domain == "com":
+            alt_link = problem_info['link'].replace("leetcode.com", "leetcode.cn")
+            embed.description = f"Solve on [LCCN (leetcode.cn)]({alt_link})."
+        else:
+            alt_link = problem_info['link'].replace("leetcode.cn", "leetcode.com")
+            embed.description = f"Solve on [LCUS (leetcode.com)]({alt_link})."
+
+        embed.add_field(name="🔥 Difficulty", value=f"**{problem_info['difficulty']}**", inline=True)
+        if problem_info.get('rating') and round(problem_info['rating']) > 0:
+            embed.add_field(name="⭐ Rating", value=f"**{round(problem_info['rating'])}**", inline=True)
+        if problem_info.get('ac_rate'):
+            embed.add_field(name="📈 AC Rate", value=f"**{round(problem_info['ac_rate'], 2)}%**", inline=True)
+        
+        if problem_info.get('tags'):    
+            tags_str = ", ".join([f"||`{tag}`||" for tag in problem_info['tags']])
+            embed.add_field(name="🏷️ Tags", value=tags_str if tags_str else "N/A", inline=False)
+        
+        # Similar questions handling (limit to avoid too much processing)
+        if problem_info.get('similar_questions'):
+            current_client = self.bot.lcus if domain == "com" else self.bot.lccn
+            similar_q_list = []
+            for sq_slug_info in problem_info['similar_questions'][:3]:
+                sq_detail = await current_client.get_problem(slug=sq_slug_info['titleSlug'])
+                if sq_detail:
+                    sq_text = f"- {emoji_map.get(sq_detail['difficulty'], '')} [{sq_detail['id']}. {sq_detail['title']}]({sq_detail['link']})"
+                    if sq_detail.get('rating') and sq_detail['rating'] > 0: 
+                        sq_text += f" *{int(sq_detail['rating'])}*"
+                    similar_q_list.append(sq_text)
+            if similar_q_list:
+                embed.add_field(name="🔍 Similar Questions", value="\n".join(similar_q_list), inline=False)
+
+        if is_daily:
+            embed.set_footer(text=f"LeetCode Daily Challenge | {problem_info.get('date', 'Today')}", icon_url="https://leetcode.com/static/images/LeetCode_logo.png")
+        else:
+            embed.set_footer(text="LeetCode Problem", icon_url="https://leetcode.com/static/images/LeetCode_logo.png")
+
+        return embed
+
+    async def create_problem_view(self, problem_info: dict, domain: str = "com"):
+        """Create a view with buttons for a LeetCode problem"""
+        view = discord.ui.View(timeout=None)
+        view.add_item(discord.ui.Button(
+            style=discord.ButtonStyle.primary,
+            label="題目描述",
+            emoji="📖",
+            custom_id=f"{self.bot.LEETCODE_DISCRIPTION_BUTTON_PREFIX}{problem_info['id']}_{domain}"
+        ))
+        if self.bot.llm:
+            view.add_item(discord.ui.Button(
+                style=discord.ButtonStyle.success,
+                label="LLM 翻譯",
+                emoji="🤖",
+                custom_id=f"{self.bot.LEETCODE_TRANSLATE_BUTTON_PREFIX}{problem_info['id']}_{domain}"
+            ))
+        if self.bot.llm_pro:
+            view.add_item(discord.ui.Button(
+                style=discord.ButtonStyle.danger,
+                label="靈感啟發",
+                emoji="💡",
+                custom_id=f"{self.bot.LEETCODE_INSPIRE_BUTTON_PREFIX}{problem_info['id']}_{domain}"
+            ))
+        return view
+
     async def send_daily_challenge(self, channel_id: int = None, role_id: int = None, interaction: discord.Interaction = None, domain: str = "com"):
         """Fetches and sends the LeetCode daily challenge."""
         try:
@@ -182,69 +257,9 @@ class ScheduleManagerCog(commands.Cog):
 
             self.logger.info(f"Got daily challenge: {challenge_info['id']}. {challenge_info['title']} for domain {domain}")
 
-            color_map = {'Easy': 0x00FF00, 'Medium': 0xFFA500, 'Hard': 0xFF0000}
-            emoji_map = {'Easy': '🟢', 'Medium': '🟡', 'Hard': '🔴'}
-            embed_color = color_map.get(challenge_info['difficulty'], 0x0099FF)
 
-            embed = discord.Embed(
-                title=f"🔗 {challenge_info['id']}. {challenge_info['title']}",
-                color=embed_color,
-                url=challenge_info['link']
-            )
-
-            if domain == "com":
-                alt_link = challenge_info['link'].replace("leetcode.com", "leetcode.cn")
-                embed.description = f"Solve on [LCCN (leetcode.cn)]({alt_link})."
-            else:
-                alt_link = challenge_info['link'].replace("leetcode.cn", "leetcode.com")
-                embed.description = f"Solve on [LCUS (leetcode.com)]({alt_link})."
-
-            embed.add_field(name="🔥 Difficulty", value=f"**{challenge_info['difficulty']}**", inline=True)
-            if challenge_info.get('rating') and round(challenge_info['rating']) > 0:
-                embed.add_field(name="⭐ Rating", value=f"**{round(challenge_info['rating'])}**", inline=True)
-            if challenge_info.get('ac_rate'):
-                embed.add_field(name="📈 AC Rate", value=f"**{round(challenge_info['ac_rate'], 2)}%**", inline=True)
-            
-            if challenge_info.get('tags'):    
-                tags_str = ", ".join([f"||`{tag}`||" for tag in challenge_info['tags']])
-                embed.add_field(name="🏷️ Tags", value=tags_str if tags_str else "N/A", inline=False)
-            
-            # Similar questions handling (limit to avoid too much processing)
-            if challenge_info.get('similar_questions'):
-                similar_q_list = []
-                for sq_slug_info in challenge_info['similar_questions'][:3]:
-                    sq_detail = await current_client.get_problem(slug=sq_slug_info['titleSlug'])
-                    if sq_detail:
-                        sq_text = f"- {emoji_map.get(sq_detail['difficulty'], '')} [{sq_detail['id']}. {sq_detail['title']}]({sq_detail['link']})"
-                        if sq_detail.get('rating') and sq_detail['rating'] > 0: 
-                            sq_text += f" *{int(sq_detail['rating'])}*"
-                        similar_q_list.append(sq_text)
-                if similar_q_list:
-                    embed.add_field(name="🔍 Similar Questions", value="\n".join(similar_q_list), inline=False)
-
-            embed.set_footer(text=f"LeetCode Daily Challenge | {challenge_info.get('date', date_str)}", icon_url="https://leetcode.com/static/images/LeetCode_logo.png")
-
-            view = discord.ui.View(timeout=None)
-            view.add_item(discord.ui.Button(
-                style=discord.ButtonStyle.primary,
-                label="題目描述",
-                emoji="📖",
-                custom_id=f"{self.bot.LEETCODE_DISCRIPTION_BUTTON_PREFIX}{challenge_info['id']}_{domain}"
-            ))
-            if self.bot.llm:
-                view.add_item(discord.ui.Button(
-                    style=discord.ButtonStyle.success,
-                    label="LLM 翻譯",
-                    emoji="🤖",
-                    custom_id=f"{self.bot.LEETCODE_TRANSLATE_BUTTON_PREFIX}{challenge_info['id']}_{domain}"
-                ))
-            if self.bot.llm_pro:
-                view.add_item(discord.ui.Button(
-                    style=discord.ButtonStyle.danger,
-                    label="靈感啟發",
-                    emoji="💡",
-                    custom_id=f"{self.bot.LEETCODE_INSPIRE_BUTTON_PREFIX}{challenge_info['id']}_{domain}"
-                ))
+            embed = await self.create_problem_embed(challenge_info, domain, is_daily=True)
+            view = await self.create_problem_view(challenge_info, domain)
 
             if interaction:
                 # If called from a slash command

--- a/uv.lock
+++ b/uv.lock
@@ -811,6 +811,7 @@ dependencies = [
     { name = "discord-py" },
     { name = "langchain" },
     { name = "langchain-google-genai" },
+    { name = "python-dotenv" },
     { name = "pytz" },
     { name = "requests" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -824,6 +825,7 @@ requires-dist = [
     { name = "discord-py", specifier = ">=2.5.2" },
     { name = "langchain", specifier = ">=0.3.23" },
     { name = "langchain-google-genai", specifier = ">=2.1.2" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
@@ -1232,6 +1234,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/cd/c59707e35a47ba4cbbf153c3f7c56420c58653b5801b055dc52cccc8e2dc/pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:52928d8c1b6bda03cc6d811e8923dffc87a2d3c8b3bfd2ce16471c7147a24850", size = 2250175, upload-time = "2025-04-02T09:49:15.597Z" },
     { url = "https://files.pythonhosted.org/packages/84/32/e4325a6676b0bed32d5b084566ec86ed7fd1e9bcbfc49c578b1755bde920/pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:1b30d92c9412beb5ac6b10a3eb7ef92ccb14e3f2a8d7732e2d739f58b3aa7544", size = 2254674, upload-time = "2025-04-02T09:49:17.61Z" },
     { url = "https://files.pythonhosted.org/packages/12/6f/5596dc418f2e292ffc661d21931ab34591952e2843e7168ea5a52591f6ff/pydantic_core-2.33.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f995719707e0e29f0f41a8aa3bcea6e761a36c9136104d3189eafb83f5cec5e5", size = 2080951, upload-time = "2025-04-02T09:49:19.559Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `/problem` command for querying LeetCode problems by ID
- Extend `/daily` and `/daily_cn` commands with optional date parameter for historical lookup
- Refactor common display logic into reusable functions
- Add automatic command synchronization on bot startup

## New Features

### `/problem` Command
- Query LeetCode problems by problem ID (1-4000+)
- Support both leetcode.com and leetcode.cn domains
- Input validation and error handling
- Auto-complete for domain selection
- Same display format as daily challenges

### Enhanced Daily Commands
- Optional `date` parameter for `/daily` and `/daily_cn`
- Support YYYY-MM-DD format for historical lookup
- Date validation with user-friendly error messages
- Backward compatible - no date means current day

### Code Improvements
- Extract `create_problem_embed()` for unified embed creation
- Extract `create_problem_view()` for consistent button layouts
- Reduce code duplication by ~200 lines
- Maintain consistent UI/UX across all commands

### Auto Command Sync
- Automatic slash command synchronization on bot startup
- Ensures new commands appear without manual intervention

## Test Plan
- [x] Syntax validation passes
- [x] Code compiles without errors
- [ ] Test `/problem` command with valid problem IDs
- [ ] Test `/problem` command with invalid inputs
- [ ] Test `/daily` with date parameter
- [ ] Test `/daily_cn` with date parameter
- [ ] Verify commands appear in Discord after bot restart
- [ ] Test backward compatibility of existing commands

🤖 Generated with [Claude Code](https://claude.ai/code)