### PR TITLE
🐛 fix(ui): improve similar question packing and link fallback coverage

### DIFF
--- a/src/bot/utils/ui_constants.py
+++ b/src/bot/utils/ui_constants.py
@@ -115,6 +115,6 @@ MAX_SIMILAR_RESULT_DETAIL_BUTTONS = MAX_PROBLEMS_PER_OVERVIEW  # 相似題目詳
 MAX_BUTTON_LABEL_LENGTH = 80  # Discord 按鈕標籤長度限制
 MAX_BUTTON_CUSTOM_ID_LENGTH = 100  # Discord custom_id 長度限制
 PROBLEMS_PER_FIELD = 5  # 每個欄位顯示的題目數量
-MAX_SIMILAR_QUESTIONS = 3  # 最多顯示的相似題目數量
+MAX_DAILY_SIMILAR_FIELD_LENGTH = 950  # daily/problem similar_questions 欄位保留安全餘量
 MAX_FIELD_LENGTH = 1024  # Discord embed 欄位最大長度
 MAX_EMBED_LENGTH = 6000  # Discord embed 總長度限制

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -33,9 +33,9 @@ from .ui_constants import (
     LUOGU_DIFFICULTY_EMOJIS,
     MAX_BUTTON_CUSTOM_ID_LENGTH,
     MAX_BUTTON_LABEL_LENGTH,
+    MAX_DAILY_SIMILAR_FIELD_LENGTH,
     MAX_FIELD_LENGTH,
     MAX_PROBLEMS_PER_OVERVIEW,
-    MAX_SIMILAR_QUESTIONS,
     MAX_SIMILAR_RESULT_DETAIL_BUTTONS,
     NON_DIFFICULTY_EMOJI,
     PROBLEMS_PER_FIELD,
@@ -107,6 +107,68 @@ def _format_similarity(value: Any) -> str:
         return f"{float(value):.2f}"
     except (TypeError, ValueError):
         return "?"
+
+
+def _format_problem_rating(value: Any) -> str | None:
+    try:
+        rating = round(float(value))
+    except (TypeError, ValueError):
+        return None
+    return str(int(rating)) if rating > 0 else None
+
+
+def _build_daily_similar_question_line(question: Dict[str, Any]) -> str | None:
+    if not isinstance(question, dict):
+        return None
+
+    title = _normalize_similar_result_segment(question.get("title"), "")
+    problem_id = _normalize_similar_result_segment(question.get("id"), "")
+    difficulty = question.get("difficulty", "")
+    emoji = get_difficulty_emoji(difficulty)
+
+    if problem_id and title:
+        display_text = f"{problem_id}. {title}"
+    else:
+        display_text = problem_id or title
+
+    if not display_text:
+        return None
+
+    link = question.get("link")
+    if not link:
+        slug = question.get("titleSlug") or question.get("slug", "")
+        if slug:
+            link = f"https://leetcode.com/problems/{slug}/"
+
+    line_text = f"[{display_text}]({link})" if link else display_text
+    rating = _format_problem_rating(question.get("rating"))
+    if rating:
+        line_text += f" *{rating}*"
+
+    return f"- {emoji} {line_text}"
+
+
+def _join_lines_with_ellipsis(lines: List[str], *, max_length: int) -> tuple[str, int, bool]:
+    if not lines:
+        return "", 0, False
+
+    rendered_lines: List[str] = []
+    for line in lines:
+        candidate = "\n".join(rendered_lines + [line])
+        if len(candidate) <= max_length:
+            rendered_lines.append(line)
+            continue
+
+        if not rendered_lines:
+            return line[: max_length - 3] + "...", 1, True
+
+        joined = "\n".join(rendered_lines)
+        ellipsis_suffix = "\n..."
+        if len(joined) + len(ellipsis_suffix) <= max_length:
+            return joined + ellipsis_suffix, len(rendered_lines), True
+        return joined[: max_length - 3] + "...", len(rendered_lines), True
+
+    return "\n".join(rendered_lines), len(rendered_lines), False
 
 
 def _build_similar_result_line(index: int, result_item: Dict[str, Any]) -> str:
@@ -347,19 +409,18 @@ async def create_problem_embed(
     # Similar questions (use data directly from API response)
     if problem_info.get("similar_questions"):
         similar_q_list = []
-        for sq in problem_info["similar_questions"][:MAX_SIMILAR_QUESTIONS]:
-            if isinstance(sq, dict):
-                sq_title = sq.get("title", "")
-                sq_slug = sq.get("titleSlug") or sq.get("slug", "")
-                sq_diff = sq.get("difficulty", "")
-                emoji = get_difficulty_emoji(sq_diff)
-                link = f"https://leetcode.com/problems/{sq_slug}/" if sq_slug else ""
-                sq_text = f"- {emoji} [{sq_title}]({link})" if link else f"- {emoji} {sq_title}"
-                similar_q_list.append(sq_text)
+        for sq in problem_info["similar_questions"]:
+            line = _build_daily_similar_question_line(sq)
+            if line:
+                similar_q_list.append(line)
         if similar_q_list:
+            similar_value, rendered_count, was_truncated = _join_lines_with_ellipsis(
+                similar_q_list, max_length=MAX_DAILY_SIMILAR_FIELD_LENGTH
+            )
+            count_suffix = "+" if was_truncated else ""
             embed.add_field(
-                name=f"{FIELD_EMOJIS['similar']} Similar Questions",
-                value="\n".join(similar_q_list),
+                name=f"{FIELD_EMOJIS['similar']} Similar Questions ({rendered_count}{count_suffix})",
+                value=similar_value,
                 inline=False,
             )
 

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -153,18 +153,20 @@ def _join_lines_with_ellipsis(lines: List[str], *, max_length: int) -> tuple[str
         return "", 0, False
 
     rendered_lines: List[str] = []
+    current_length = 0
     for line in lines:
-        candidate = "\n".join(rendered_lines + [line])
-        if len(candidate) <= max_length:
+        needed_length = len(line) + (1 if rendered_lines else 0)
+        if current_length + needed_length <= max_length:
             rendered_lines.append(line)
+            current_length += needed_length
             continue
 
         if not rendered_lines:
             return line[: max_length - 3] + "...", 1, True
 
-        joined = "\n".join(rendered_lines)
         ellipsis_suffix = "\n..."
-        if len(joined) + len(ellipsis_suffix) <= max_length:
+        joined = "\n".join(rendered_lines)
+        if current_length + len(ellipsis_suffix) <= max_length:
             return joined + ellipsis_suffix, len(rendered_lines), True
         return joined[: max_length - 3] + "...", len(rendered_lines), True
 

--- a/tests/test_slash_problem_command.py
+++ b/tests/test_slash_problem_command.py
@@ -5,7 +5,13 @@ import pytest
 from discord.ext import commands
 
 from bot.cogs.slash_commands_cog import SlashCommandsCog
-from bot.utils.ui_constants import LUOGU_DIFFICULTY_COLORS, LUOGU_DIFFICULTY_EMOJIS, NON_DIFFICULTY_EMOJI
+from bot.utils.ui_constants import (
+    LUOGU_DIFFICULTY_COLORS,
+    LUOGU_DIFFICULTY_EMOJIS,
+    MAX_DAILY_SIMILAR_FIELD_LENGTH,
+    NON_DIFFICULTY_EMOJI,
+)
+from bot.utils.ui_helpers import create_problem_embed
 
 
 def _make_interaction():
@@ -201,3 +207,77 @@ async def test_problem_command_luogu_multiple_uses_difficulty_emojis():
     assert button_emojis == [LUOGU_DIFFICULTY_EMOJIS["入门"], LUOGU_DIFFICULTY_EMOJIS["普及/提高-"]]
     assert all(button.custom_id.startswith("problem|luogu|") for button in kwargs["view"].children)
     assert all(button.custom_id.endswith("|view") for button in kwargs["view"].children)
+
+
+@pytest.mark.asyncio
+async def test_create_problem_embed_formats_daily_similar_questions_with_id_link_and_rating():
+    bot = _make_bot()
+    problem = {
+        "id": "1",
+        "source": "leetcode",
+        "slug": "two-sum",
+        "title": "Two Sum",
+        "difficulty": "Easy",
+        "ac_rate": 52.34,
+        "rating": 1234,
+        "tags": ["Array", "Hash Table"],
+        "link": "https://leetcode.com/problems/two-sum/",
+        "similar_questions": [
+            {
+                "id": "48",
+                "source": "leetcode",
+                "slug": "rotate-image",
+                "title": "Rotate Image",
+                "difficulty": "Medium",
+                "rating": 2010,
+                "link": "https://leetcode.com/problems/rotate-image/",
+            }
+        ],
+    }
+
+    embed = await create_problem_embed(problem_info=problem, bot=bot, is_daily=True)
+
+    similar_field = next(field for field in embed.fields if field.name == "🔍 Similar Questions (1)")
+    assert similar_field.value == "- 🟡 [48. Rotate Image](https://leetcode.com/problems/rotate-image/) *2010*"
+
+
+@pytest.mark.asyncio
+async def test_create_problem_embed_packs_all_daily_similar_questions_within_length_budget():
+    bot = _make_bot()
+    long_title = "B" * 180
+    similar_questions = []
+    for i in range(1, 10):
+        similar_questions.append(
+            {
+                "id": str(100 + i),
+                "source": "leetcode",
+                "slug": f"sample-problem-{i}",
+                "title": f"{long_title}-{i}",
+                "difficulty": "Medium",
+                "rating": 1800 + i,
+                "link": f"https://leetcode.com/problems/sample-problem-{i}/",
+            }
+        )
+
+    problem = {
+        "id": "1",
+        "source": "leetcode",
+        "slug": "two-sum",
+        "title": "Two Sum",
+        "difficulty": "Easy",
+        "ac_rate": 52.34,
+        "rating": 1234,
+        "tags": ["Array"],
+        "link": "https://leetcode.com/problems/two-sum/",
+        "similar_questions": similar_questions,
+    }
+
+    embed = await create_problem_embed(problem_info=problem, bot=bot, is_daily=True)
+
+    similar_field = next(field for field in embed.fields if field.name == "🔍 Similar Questions (3+)")
+    lines = similar_field.value.split("\n")
+
+    assert len(similar_field.value) <= MAX_DAILY_SIMILAR_FIELD_LENGTH
+    assert len(lines) > 3
+    assert lines[0].startswith("- 🟡 [101. ")
+    assert similar_field.value.endswith("...")

--- a/tests/test_slash_problem_command.py
+++ b/tests/test_slash_problem_command.py
@@ -281,3 +281,39 @@ async def test_create_problem_embed_packs_all_daily_similar_questions_within_len
     assert len(lines) > 3
     assert lines[0].startswith("- 🟡 [101. ")
     assert similar_field.value.endswith("...")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("slug_key", "slug_value"),
+    [("titleSlug", "rotate-image"), ("slug", "best-time-to-buy-and-sell-stock")],
+)
+async def test_create_problem_embed_builds_daily_similar_question_link_from_slug_when_link_missing(
+    slug_key: str, slug_value: str
+):
+    bot = _make_bot()
+    problem = {
+        "id": "1",
+        "source": "leetcode",
+        "slug": "two-sum",
+        "title": "Two Sum",
+        "difficulty": "Easy",
+        "ac_rate": 52.34,
+        "rating": 1234,
+        "tags": ["Array"],
+        "link": "https://leetcode.com/problems/two-sum/",
+        "similar_questions": [
+            {
+                "id": "48",
+                "source": "leetcode",
+                "title": "Similar Problem",
+                "difficulty": "Medium",
+                slug_key: slug_value,
+            }
+        ],
+    }
+
+    embed = await create_problem_embed(problem_info=problem, bot=bot, is_daily=True)
+
+    similar_field = next(field for field in embed.fields if field.name == "🔍 Similar Questions (1)")
+    assert similar_field.value == f"- 🟡 [48. Similar Problem](https://leetcode.com/problems/{slug_value}/)"


### PR DESCRIPTION
## Summary

Improve daily/problem similar-question rendering so embeds can show more related problems without overflowing Discord field limits.

This branch:
- replaces the old fixed 3-item cap with a safe field-length budget
- formats similar-question entries with id, title, link, rating, and difficulty emoji
- adds explicit `(N)` / `(N+)` labels plus trailing `...` when content is truncated
- adds regression coverage for missing direct-link payloads by falling back to `titleSlug` / `slug`

## Changes

- `src/bot/utils/ui_constants.py`
  - add `MAX_DAILY_SIMILAR_FIELD_LENGTH = 950` as a safer embed field budget

- `src/bot/utils/ui_helpers.py`
  - add helper to format daily similar-question lines
  - add helper to join/truncate lines within the field-length budget
  - update `create_problem_embed()` to render as many similar questions as fit

- `tests/test_slash_problem_command.py`
  - verify formatted output includes id, link, and rating
  - verify long similar-question lists are packed within the budget and show truncation markers
  - verify missing `link` falls back to LeetCode URLs built from `titleSlug` / `slug`

## Why

Discord embed fields are length-limited, and the previous implementation left useful space unused by hard-capping the list at 3 items. This change improves information density while preserving safe rendering behavior.

## Testing

- `ruff check tests/test_slash_problem_command.py`
- `.venv/bin/pytest -q tests/test_slash_problem_command.py tests/test_similar_results.py tests/test_interaction_handler.py`
