### PR TITLE
✨ feat(random): add /random command with filtered random problem selection

### DIFF
--- a/openspec/changes/archive/2026-04-29-random-problem-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-random-problem-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-random-problem-command/design.md
+++ b/openspec/changes/archive/2026-04-29-random-problem-command/design.md
@@ -1,0 +1,94 @@
+# Design: /random Command
+
+## Context
+
+Users need a quick way to get random LeetCode problems for practice beyond daily challenges. The `/random` command will leverage existing OJ API filtering capabilities and reuse established UI components.
+
+**Current State:**
+- SlashCommandsCog already handles `/daily`, `/problem`, `/recent`, `/config`
+- OjApiClient provides `get_problem()`, `get_daily()`, `resolve()`, `search_similar()`
+- UI helpers (`create_problem_embed`, `create_problem_view`) are source-aware and reusable
+- InteractionHandlerCog routes button clicks via `problem|{source}|{id}|{action}` format
+
+**Constraints:**
+- LeetCode-only for v1 (no multi-source support)
+- No local problem cache/index (API provides full filtering)
+- Discord 3-second interaction timeout requires `defer()`
+
+## Goals / Non-Goals
+
+**Goals:**
+- `/random` command with difficulty, tags, rating_min, rating_max filters
+- Reuse existing UI components for consistent display
+- Maintain error handling patterns (ApiProcessingError, ApiNetworkError, ApiRateLimitError)
+- Clear error messages when no problems match filters
+
+**Non-Goals:**
+- Multi-source support (AtCoder, Codeforces, etc.)
+- Local problem caching or indexing
+- Tag autocomplete (requires additional API support)
+- User history exclusion (avoid repeat recommendations)
+
+## Decisions
+
+### Decision 1: Two-Call API Strategy
+**Choice:** Bot-side random selection via two API calls (count → random page → fetch item)
+
+**Rationale:**
+- OJ API already supports filtered listing with pagination
+- No need to modify upstream API
+- Minimal code change, reuses existing HTTP client
+
+**Alternatives Considered:**
+- Server-side random endpoint: Cleaner but requires upstream API work outside this repo
+- Local cached index: Contradicts proposal scope, adds sync complexity
+- Random ID probing: Inefficient, fails for sparse IDs and non-ID filters
+
+### Decision 2: Placement in SlashCommandsCog
+**Choice:** Add `/random` to existing SlashCommandsCog rather than new cog
+
+**Rationale:**
+- `/daily` and `/problem` already live there with same public/ephemeral behavior
+- Exception mapping and defer pattern are established
+- Consistent with existing architecture
+
+### Decision 3: Rating Parameter Auto-Swap
+**Choice:** Automatically swap rating_min and rating_max when min > max
+
+**Rationale:**
+- User-friendly: prevents silent zero-result queries
+- Follows principle of least surprise
+- Simple validation logic
+
+### Decision 4: Filter Summary in Error Messages
+**Choice:** Show applied filters in no-result error messages
+
+**Rationale:**
+- Helps users understand why no problems matched
+- Guides them to adjust filter criteria
+- Better UX than generic "no results" message
+
+## Risks / Trade-offs
+
+**Risk 1: Two API calls increase latency and failure probability**
+→ Mitigation: Use `defer()` to handle Discord timeout; accept slightly higher latency for filtered random selection
+
+**Risk 2: Race condition between count and page fetch**
+→ Mitigation: If selected page returns empty, retry with different random offset (bounded retries)
+
+**Risk 3: OJ API list endpoint response shape not codified in tests**
+→ Mitigation: Add contract tests during implementation; document expected response format
+
+**Risk 4: Randomness complicates deterministic testing**
+→ Mitigation: Use RNG injection or monkeypatching in tests; log selected random seed for debugging
+
+**Risk 5: Input normalization ambiguity for tags**
+→ Mitigation: Pass tags as-is to API (single tag per parameter); document encoding behavior
+
+## Implementation Approach
+
+1. **OjApiClient.get_random_problem()**: New method with two-call strategy
+2. **SlashCommandsCog.random_command()**: New command with filter parameters
+3. **Error handling**: Reuse existing ApiError mapping
+4. **UI rendering**: Reuse create_problem_embed() and create_problem_view()
+5. **Testing**: Unit tests for parameter validation, integration tests for API flow

--- a/openspec/changes/archive/2026-04-29-random-problem-command/proposal.md
+++ b/openspec/changes/archive/2026-04-29-random-problem-command/proposal.md
@@ -1,0 +1,71 @@
+# Proposal: /random 指令
+
+## 概述
+
+新增 `/random` 斜線指令，讓使用者可以隨機取得 LeetCode 題目，並支援難度、標籤、評分範圍篩選。
+
+## 動機
+
+使用者在日常練習時，除了每日挑戰外，也需要一個快速取得隨機題目的方式。`/random` 可以搭配篩選條件，幫助使用者針對特定難度或主題進行練習。
+
+## 技術發現
+
+### 後端 API 已支援
+
+OJ API (`GET /api/v1/problems/{source}`) 已支援以下篩選與分頁參數：
+- `difficulty`: Easy / Medium / Hard
+- `tags`: 標籤篩選
+- `rating_min` / `rating_max`: 評分範圍
+- `per_page` + 頁碼分頁
+
+實作策略：兩次 API 呼叫 — 第一次取總數 → 隨機選頁 → 第二次取題目。
+
+### 現有架構可複用
+
+| 模組 | 複用方式 |
+|------|---------|
+| `create_problem_embed` | 產生題目 Embed（含難度顏色） |
+| `create_problem_view` | 產生互動按鈕（描述/翻譯/靈感/相似） |
+| `InteractionHandlerCog` | 已有 `problem\|{source}\|{id}\|{action}` 統一路由 |
+| 錯誤處理模式 | 沿用 `ApiProcessingError` / `ApiNetworkError` / `ApiRateLimitError` 標準映射 |
+
+### 無需新增本地快取
+
+資料庫目前不存儲可搜尋的題目目錄，但後端 API 已提供完整篩選能力，無需引入本地快取架構。
+
+## 使用者確認
+
+- **題庫來源**：僅 LeetCode（第一版）
+- **Rating 篩選**：支援 `rating_min` / `rating_max`
+- **預設行為**：無篩選條件時，從全題庫隨機
+
+## 範圍
+
+### 包含
+
+- `/random` 斜線指令，支援以下參數：
+  - `difficulty`: 難度篩選 (Easy/Medium/Hard)
+  - `tags`: 標籤篩選
+  - `rating_min`: 最低評分
+  - `rating_max`: 最高評分
+  - `public`: 是否公開顯示（沿用現有慣例）
+- `OjApiClient` 新增 `get_random_problem()` 方法
+- 沿用現有 UI 組件（Embed + View + 按鈕互動）
+- `config.toml.example` 更新文件
+
+### 不包含
+
+- 多來源支援（AtCoder、Codeforces 等）— 留待後續版本
+- 本地題目快取/索引
+- 標籤自動完成（需額外 API 支援）
+- 使用者歷史排除（避免重複推薦）
+
+## 驗收標準
+
+1. `/random` 回傳一個有效的 LeetCode 題目 Embed
+2. `/random difficulty:Medium` 只回傳 Medium 難度題目
+3. `/random tags:Array` 只回傳包含 Array 標籤的題目
+4. `/random rating_min:1500 rating_max:2000` 只回傳評分在範圍內的題目
+5. 無符合條件時，顯示明確的錯誤訊息
+6. 回傳的題目包含所有標準互動按鈕（描述/翻譯/靈感/相似）
+7. 錯誤處理與其他指令一致（Processing/Network/RateLimit/API）

--- a/openspec/changes/archive/2026-04-29-random-problem-command/specs/random-problem-command/spec.md
+++ b/openspec/changes/archive/2026-04-29-random-problem-command/specs/random-problem-command/spec.md
@@ -1,0 +1,75 @@
+# random-problem-command Specification
+
+## ADDED Requirements
+
+### Requirement: Random problem command
+The `/random` command SHALL fetch and display a random LeetCode problem with optional filtering.
+
+#### Scenario: Fetch random problem without filters
+- **WHEN** a user runs `/random` without any filter parameters
+- **THEN** the bot SHALL display a random problem from the entire LeetCode problem set with problem info, difficulty, tags, and interactive buttons
+
+#### Scenario: Fetch random problem with difficulty filter
+- **WHEN** a user runs `/random difficulty:Medium`
+- **THEN** the bot SHALL display a random problem that has difficulty "Medium"
+
+#### Scenario: Fetch random problem with tags filter
+- **WHEN** a user runs `/random tags:Array`
+- **THEN** the bot SHALL display a random problem that includes the "Array" tag
+
+#### Scenario: Fetch random problem with rating range
+- **WHEN** a user runs `/random rating_min:1500 rating_max:2000`
+- **THEN** the bot SHALL display a random problem with rating between 1500 and 2000 (inclusive)
+
+#### Scenario: Public toggle
+- **WHEN** a user runs `/random` with the `public` parameter set to True
+- **THEN** the response SHALL be visible to all users in the channel instead of ephemeral
+
+#### Scenario: No matching problems
+- **WHEN** a user runs `/random` with filter conditions that match no problems
+- **THEN** the bot SHALL display an ephemeral error message showing the applied filter summary (e.g., "沒有找到符合 difficulty:Hard, tags:Array, rating:1500-2000 的題目")
+
+### Requirement: Rating parameter validation
+The `/random` command SHALL validate and normalize rating parameters.
+
+#### Scenario: Rating min greater than max
+- **WHEN** a user runs `/random rating_min:2000 rating_max:1500`
+- **THEN** the bot SHALL automatically swap the values and use rating_min=1500, rating_max=2000
+
+#### Scenario: Single rating bound
+- **WHEN** a user runs `/random rating_min:1500` without rating_max
+- **THEN** the bot SHALL use rating_min=1500 with no upper bound
+
+#### Scenario: Rating boundary inclusive
+- **WHEN** a user runs `/random rating_min:1500 rating_max:1500`
+- **THEN** the bot SHALL display problems with rating exactly 1500
+
+### Requirement: API client random problem method
+The `OjApiClient` SHALL provide a `get_random_problem()` method that performs filtered random selection.
+
+#### Scenario: Two-call random selection
+- **WHEN** `get_random_problem()` is called with filters
+- **THEN** the method SHALL first fetch the total count of matching problems, then fetch one random problem from the filtered set
+
+#### Scenario: Zero results handling
+- **WHEN** `get_random_problem()` is called and the API returns total count of 0
+- **THEN** the method SHALL return a domain-level no-match result (not an API error)
+
+#### Scenario: API error propagation
+- **WHEN** `get_random_problem()` encounters API errors (429, timeout, network failure)
+- **THEN** the method SHALL propagate standard error types (ApiRateLimitError, ApiNetworkError, ApiProcessingError)
+
+### Requirement: UI component reuse
+The `/random` command SHALL reuse existing UI components for consistent display.
+
+#### Scenario: Problem embed format
+- **WHEN** a random problem is successfully fetched
+- **THEN** the bot SHALL use `create_problem_embed()` to generate the embed with difficulty color, tags, and rating
+
+#### Scenario: Interactive buttons
+- **WHEN** a random problem is displayed
+- **THEN** the bot SHALL use `create_problem_view()` to generate buttons for description, translation, inspiration, and similar problems
+
+#### Scenario: Button interaction routing
+- **WHEN** a user clicks any button on a random problem
+- **THEN** the interaction SHALL be routed through `InteractionHandlerCog` using the standard `problem|{source}|{id}|{action}` format

--- a/openspec/changes/archive/2026-04-29-random-problem-command/tasks.md
+++ b/openspec/changes/archive/2026-04-29-random-problem-command/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: /random Command
+
+## 1. API Client Implementation
+
+- [x] 1.1 Add `get_random_problem()` method to OjApiClient with two-call strategy (count → random page → fetch item)
+- [x] 1.2 Implement filter parameter handling (difficulty, tags, rating_min, rating_max)
+- [x] 1.3 Add rating parameter auto-swap logic when min > max
+- [x] 1.4 Implement zero-results handling (return domain-level no-match, not API error)
+- [x] 1.5 Add error propagation for API errors (429, timeout, network failure)
+
+## 2. Slash Command Implementation
+
+- [x] 2.1 Add `/random` command to SlashCommandsCog with filter parameters
+- [x] 2.2 Implement parameter validation (difficulty enum, rating bounds)
+- [x] 2.3 Add `public` parameter handling (ephemeral vs visible)
+- [x] 2.4 Implement defer pattern for Discord timeout handling
+- [x] 2.5 Add error handling with filter summary in no-result messages
+
+## 3. UI Integration
+
+- [x] 3.1 Integrate `create_problem_embed()` for random problem display
+- [x] 3.2 Integrate `create_problem_view()` for interactive buttons
+- [x] 3.3 Verify button routing through InteractionHandlerCog
+
+## 4. Testing
+
+- [x] 4.1 Add unit tests for parameter validation and rating swap logic
+- [x] 4.2 Add unit tests for `get_random_problem()` method with mocked API responses
+- [x] 4.3 Add integration tests for `/random` command with various filter combinations
+- [x] 4.4 Add edge case tests (no results, API errors, boundary conditions)
+
+## 5. Documentation
+
+- [x] 5.1 Update `config.toml.example` with any new configuration if needed
+- [x] 5.2 Verify command works with both leetcode.com and leetcode.cn sources

--- a/openspec/specs/slash-commands/spec.md
+++ b/openspec/specs/slash-commands/spec.md
@@ -168,3 +168,75 @@ The `/config` command SHALL provide autocomplete suggestions for the `timezone` 
 - **WHEN** the user types "Asia" in the timezone field
 - **THEN** the bot SHALL filter suggestions to show matching IANA zones (e.g., Asia/Taipei, Asia/Tokyo, Asia/Shanghai)
 
+### Requirement: Random problem command
+The `/random` command SHALL fetch and display a random LeetCode problem with optional filtering.
+
+#### Scenario: Fetch random problem without filters
+- **WHEN** a user runs `/random` without any filter parameters
+- **THEN** the bot SHALL display a random problem from the entire LeetCode problem set with problem info, difficulty, tags, and interactive buttons
+
+#### Scenario: Fetch random problem with difficulty filter
+- **WHEN** a user runs `/random difficulty:Medium`
+- **THEN** the bot SHALL display a random problem that has difficulty "Medium"
+
+#### Scenario: Fetch random problem with tags filter
+- **WHEN** a user runs `/random tags:Array`
+- **THEN** the bot SHALL display a random problem that includes the "Array" tag
+
+#### Scenario: Fetch random problem with rating range
+- **WHEN** a user runs `/random rating_min:1500 rating_max:2000`
+- **THEN** the bot SHALL display a random problem with rating between 1500 and 2000 (inclusive)
+
+#### Scenario: Public toggle
+- **WHEN** a user runs `/random` with the `public` parameter set to True
+- **THEN** the response SHALL be visible to all users in the channel instead of ephemeral
+
+#### Scenario: No matching problems
+- **WHEN** a user runs `/random` with filter conditions that match no problems
+- **THEN** the bot SHALL display an ephemeral error message showing the applied filter summary (e.g., "沒有找到符合 difficulty:Hard, tags:Array, rating:1500-2000 的題目")
+
+### Requirement: Rating parameter validation
+The `/random` command SHALL validate and normalize rating parameters.
+
+#### Scenario: Rating min greater than max
+- **WHEN** a user runs `/random rating_min:2000 rating_max:1500`
+- **THEN** the bot SHALL automatically swap the values and use rating_min=1500, rating_max=2000
+
+#### Scenario: Single rating bound
+- **WHEN** a user runs `/random rating_min:1500` without rating_max
+- **THEN** the bot SHALL use rating_min=1500 with no upper bound
+
+#### Scenario: Rating boundary inclusive
+- **WHEN** a user runs `/random rating_min:1500 rating_max:1500`
+- **THEN** the bot SHALL display problems with rating exactly 1500
+
+### Requirement: API client random problem method
+The `OjApiClient` SHALL provide a `get_random_problem()` method that performs filtered random selection.
+
+#### Scenario: Two-call random selection
+- **WHEN** `get_random_problem()` is called with filters
+- **THEN** the method SHALL first fetch the total count of matching problems, then fetch one random problem from the filtered set
+
+#### Scenario: Zero results handling
+- **WHEN** `get_random_problem()` is called and the API returns total count of 0
+- **THEN** the method SHALL return a domain-level no-match result (not an API error)
+
+#### Scenario: API error propagation
+- **WHEN** `get_random_problem()` encounters API errors (429, timeout, network failure)
+- **THEN** the method SHALL propagate standard error types (ApiRateLimitError, ApiNetworkError, ApiProcessingError)
+
+### Requirement: UI component reuse
+The `/random` command SHALL reuse existing UI components for consistent display.
+
+#### Scenario: Problem embed format
+- **WHEN** a random problem is successfully fetched
+- **THEN** the bot SHALL use `create_problem_embed()` to generate the embed with difficulty color, tags, and rating
+
+#### Scenario: Interactive buttons
+- **WHEN** a random problem is displayed
+- **THEN** the bot SHALL use `create_problem_view()` to generate buttons for description, translation, inspiration, and similar problems
+
+#### Scenario: Button interaction routing
+- **WHEN** a user clicks any button on a random problem
+- **THEN** the interaction SHALL be routed through `InteractionHandlerCog` using the standard `problem|{source}|{id}|{action}` format
+

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 from urllib.parse import quote
 
 import aiohttp
@@ -150,3 +151,54 @@ class OjApiClient:
         if source:
             params["source"] = source
         return await self._request("GET", "similar", params=params)
+
+    async def get_random_problem(
+        self,
+        *,
+        difficulty: str | None = None,
+        tags: str | None = None,
+        rating_min: int | None = None,
+        rating_max: int | None = None,
+    ) -> dict | None:
+        """Fetch a random LeetCode problem via two-call strategy.
+
+        Returns the problem dict on success, None if no problems match,
+        or propagates standard API errors.
+        """
+        if rating_min is not None and rating_max is not None and rating_min > rating_max:
+            rating_min, rating_max = rating_max, rating_min
+
+        base_params: dict[str, str | int] = {"per_page": 1}
+        if difficulty:
+            base_params["difficulty"] = difficulty
+        if tags:
+            base_params["tags"] = tags
+        if rating_min is not None:
+            base_params["rating_min"] = rating_min
+        if rating_max is not None:
+            base_params["rating_max"] = rating_max
+
+        count_resp = await self._request("GET", "problems/leetcode", params=base_params)
+        if not count_resp:
+            return None
+
+        total = count_resp.get("total") or 0
+        if total == 0:
+            return None
+
+        random_page = random.randint(1, total)
+        page_params = {**base_params, "page": random_page}
+        result = await self._request("GET", "problems/leetcode", params=page_params)
+        if not result:
+            return None
+
+        items = result.get("results", result.get("items", [])) or []
+        if not items:
+            # TOCTOU fallback: dataset shrank between count and fetch
+            page_params["page"] = 1
+            result = await self._request("GET", "problems/leetcode", params=page_params)
+            if not result:
+                return None
+            items = result.get("results", result.get("items", [])) or []
+
+        return items[0] if items else None

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -95,6 +95,92 @@ class SlashCommandsCog(commands.Cog):
             self.logger.error("Error in daily command with date %s: %s", date, e, exc_info=True)
             await interaction.followup.send(f"查詢每日挑戰時發生錯誤：{e}", ephemeral=not public)
 
+    # ── /random ────────────────────────────────────────────────────────
+
+    @app_commands.command(name="random", description="隨機取得一道 LeetCode 題目")
+    @app_commands.describe(
+        difficulty="難度篩選",
+        tags="標籤篩選 (例如: Array)",
+        rating_min="最低評分",
+        rating_max="最高評分",
+        public="是否公開顯示回覆 (預設為私密回覆)",
+    )
+    @app_commands.choices(
+        difficulty=[
+            app_commands.Choice(name="Easy", value="Easy"),
+            app_commands.Choice(name="Medium", value="Medium"),
+            app_commands.Choice(name="Hard", value="Hard"),
+        ]
+    )
+    async def random_command(
+        self,
+        interaction: discord.Interaction,
+        difficulty: str = None,
+        tags: str = None,
+        rating_min: int = None,
+        rating_max: int = None,
+        public: bool = False,
+    ):
+        if rating_min is not None and rating_max is not None and rating_min > rating_max:
+            rating_min, rating_max = rating_max, rating_min
+
+        await interaction.response.defer(ephemeral=not public)
+
+        try:
+            problem = await self.bot.api.get_random_problem(
+                difficulty=difficulty,
+                tags=tags,
+                rating_min=rating_min,
+                rating_max=rating_max,
+            )
+            if not problem:
+                filters = []
+                if difficulty:
+                    filters.append(f"difficulty:{difficulty}")
+                if tags:
+                    filters.append(f"tags:{discord.utils.escape_markdown(tags)}")
+                if rating_min is not None or rating_max is not None:
+                    r_min = str(rating_min) if rating_min is not None else "不限"
+                    r_max = str(rating_max) if rating_max is not None else "不限"
+                    filters.append(f"rating:{r_min}-{r_max}")
+                filter_text = ", ".join(filters) if filters else "無篩選條件"
+                await interaction.followup.send(
+                    f"沒有找到符合 {filter_text} 的題目，請調整篩選條件後重試。",
+                    ephemeral=True,
+                    allowed_mentions=discord.AllowedMentions.none(),
+                )
+                return
+
+            source = problem.get("source", "leetcode")
+            domain = "cn" if source == "leetcode" and problem.get("domain") == "cn" else "com"
+            embed = await create_problem_embed(
+                problem_info=problem,
+                bot=self.bot,
+                domain=domain,
+                is_daily=False,
+                user=interaction.user,
+            )
+            view = await create_problem_view(problem_info=problem, bot=self.bot, domain=domain)
+            await interaction.followup.send(embed=embed, view=view, ephemeral=not public)
+            self.logger.info("Sent random problem to user %s", interaction.user.name)
+
+        except ApiProcessingError:
+            await interaction.followup.send("⏳ 資料準備中，請稍後重試。", ephemeral=not public)
+        except ApiNetworkError:
+            await interaction.followup.send("🔌 API 連線失敗，請稍後重試。", ephemeral=not public)
+        except ApiRateLimitError:
+            await interaction.followup.send("⏱️ 請求頻率過高，請稍後重試。", ephemeral=not public)
+        except ApiError as e:
+            self.logger.error("API error in random command: %s", e)
+            await interaction.followup.send("❌ 查詢失敗，請稍後重試。", ephemeral=not public)
+        except Exception as e:
+            self.logger.error("Error in random_command: %s", e, exc_info=True)
+            await interaction.followup.send(
+                "❌ 隨機題目時發生未預期錯誤，請稍後重試。",
+                ephemeral=not public,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+
     # ── /problem ──────────────────────────────────────────────────────
 
     @app_commands.command(name="problem", description="根據題號查詢題目資訊")

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -1,0 +1,382 @@
+import random
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord.ext import commands
+
+from bot.api_client import ApiError, ApiNetworkError, ApiProcessingError, ApiRateLimitError, OjApiClient
+from bot.cogs.slash_commands_cog import SlashCommandsCog
+
+# -- helpers --
+
+
+def _make_interaction():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.response = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    user = MagicMock()
+    user.name = "tester"
+    user.display_name = "tester"
+    user.display_avatar = MagicMock(url="https://example.com/avatar.png")
+    interaction.user = user
+    return interaction
+
+
+def _make_bot():
+    bot = MagicMock(spec=commands.Bot)
+    bot.api = AsyncMock()
+    bot.llm = MagicMock()
+    bot.llm_pro = MagicMock()
+    return bot
+
+
+def _sample_problem(problem_id: str = "1", difficulty: str = "Easy") -> dict:
+    return {
+        "id": problem_id,
+        "source": "leetcode",
+        "slug": "two-sum",
+        "title": "Two Sum",
+        "difficulty": difficulty,
+        "ac_rate": 52.34,
+        "rating": 1234,
+        "tags": ["Array", "Hash Table"],
+        "link": "https://leetcode.com/problems/two-sum/",
+        "content": None,
+        "content_cn": None,
+        "similar_questions": None,
+    }
+
+
+# -- get_random_problem tests --
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_returns_none_on_zero_count():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value={"total": 0, "results": []})
+
+    result = await api.get_random_problem()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_returns_none_on_empty_response():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=None)
+
+    result = await api.get_random_problem()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_swaps_rating_when_min_exceeds_max():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+
+    captured_params = []
+
+    async def fake_request(method, path, **kwargs):
+        params = kwargs.get("params", {})
+        captured_params.append(params)
+        if "page" not in params:
+            return {"total": 5, "results": []}
+        return {"total": 5, "results": [_sample_problem()]}
+
+    api._request = AsyncMock(side_effect=fake_request)
+
+    await api.get_random_problem(rating_min=2000, rating_max=1500)
+
+    # First call (count) should have swapped values
+    assert captured_params[0]["rating_min"] == 1500
+    assert captured_params[0]["rating_max"] == 2000
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_passes_all_filters():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+
+    captured_params = []
+
+    async def fake_request(method, path, **kwargs):
+        params = kwargs.get("params", {})
+        captured_params.append(params)
+        if "page" not in params:
+            return {"total": 3, "results": []}
+        return {"total": 3, "results": [_sample_problem()]}
+
+    api._request = AsyncMock(side_effect=fake_request)
+
+    await api.get_random_problem(difficulty="Medium", tags="Array", rating_min=1500, rating_max=2000)
+
+    assert captured_params[0]["difficulty"] == "Medium"
+    assert captured_params[0]["tags"] == "Array"
+    assert captured_params[0]["rating_min"] == 1500
+    assert captured_params[0]["rating_max"] == 2000
+    assert captured_params[0]["per_page"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_uses_random_page(monkeypatch):
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+
+    captured_params = []
+
+    async def fake_request(method, path, **kwargs):
+        params = kwargs.get("params", {})
+        captured_params.append(params)
+        if "page" not in params:
+            return {"total": 10, "results": []}
+        return {"total": 10, "results": [_sample_problem()]}
+
+    api._request = AsyncMock(side_effect=fake_request)
+    monkeypatch.setattr(random, "randint", lambda a, b: 7)
+
+    result = await api.get_random_problem()
+
+    assert result is not None
+    assert captured_params[1]["page"] == 7
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_propagates_api_error():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=ApiNetworkError("timeout"))
+
+    with pytest.raises(ApiNetworkError):
+        await api.get_random_problem()
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_propagates_rate_limit():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=ApiRateLimitError(5.0))
+
+    with pytest.raises(ApiRateLimitError):
+        await api.get_random_problem()
+
+
+@pytest.mark.asyncio
+async def test_get_random_problem_fallback_on_empty_page():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+
+    call_count = 0
+
+    async def fake_request(method, path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        params = kwargs.get("params", {})
+        if "page" not in params:
+            return {"total": 5, "results": []}
+        if call_count == 2:
+            return {"total": 5, "results": []}  # random page is empty
+        return {"total": 5, "results": [_sample_problem()]}  # fallback page=1
+
+    api._request = AsyncMock(side_effect=fake_request)
+
+    result = await api.get_random_problem()
+    assert result is not None
+    assert call_count == 3  # count + empty page + fallback
+
+
+# -- /random command tests --
+
+
+@pytest.mark.asyncio
+async def test_random_command_sends_problem_embed_and_view():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = _sample_problem()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction)
+
+    interaction.response.defer.assert_called_once_with(ephemeral=True)
+    assert interaction.followup.send.call_count == 1
+    _, kwargs = interaction.followup.send.call_args
+    assert "embed" in kwargs
+    assert "view" in kwargs
+
+
+@pytest.mark.asyncio
+async def test_random_command_with_difficulty_filter():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = _sample_problem(difficulty="Medium")
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, difficulty="Medium")
+
+    bot.api.get_random_problem.assert_called_once_with(difficulty="Medium", tags=None, rating_min=None, rating_max=None)
+
+
+@pytest.mark.asyncio
+async def test_random_command_with_all_filters():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = _sample_problem()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, difficulty="Hard", tags="DP", rating_min=1500, rating_max=2500)
+
+    bot.api.get_random_problem.assert_called_once_with(difficulty="Hard", tags="DP", rating_min=1500, rating_max=2500)
+
+
+@pytest.mark.asyncio
+async def test_random_command_swaps_rating_before_api():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = _sample_problem()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, rating_min=2000, rating_max=1500)
+
+    bot.api.get_random_problem.assert_called_once_with(difficulty=None, tags=None, rating_min=1500, rating_max=2000)
+
+
+@pytest.mark.asyncio
+async def test_random_command_public_flag():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = _sample_problem()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, public=True)
+
+    interaction.response.defer.assert_called_once_with(ephemeral=False)
+    interaction.followup.send.assert_called_once()
+    _, kwargs = interaction.followup.send.call_args
+    assert kwargs["ephemeral"] is False
+
+
+@pytest.mark.asyncio
+async def test_random_command_no_results_shows_filter_summary():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = None
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, difficulty="Hard", tags="DP", rating_min=1500, rating_max=2000)
+
+    _, kwargs = interaction.followup.send.call_args
+    call_str = str(interaction.followup.send.call_args)
+    assert "difficulty:Hard" in call_str
+    assert "tags:DP" in call_str
+    assert "rating:1500-2000" in call_str
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_random_command_no_results_always_ephemeral():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = None
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, public=True)
+
+    _, kwargs = interaction.followup.send.call_args
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_random_command_no_results_no_filters():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = None
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction)
+
+    call_args_str = str(interaction.followup.send.call_args)
+    assert "無篩選條件" in call_args_str
+
+
+@pytest.mark.asyncio
+async def test_random_command_no_results_disables_mentions():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = None
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, tags="@everyone")
+
+    _, kwargs = interaction.followup.send.call_args
+    mentions = kwargs["allowed_mentions"]
+    assert mentions.everyone is False
+    assert mentions.users is False
+    assert mentions.roles is False
+
+
+@pytest.mark.asyncio
+async def test_random_command_handles_api_processing_error():
+    bot = _make_bot()
+    bot.api.get_random_problem.side_effect = ApiProcessingError()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction)
+
+    call_args_str = str(interaction.followup.send.call_args)
+    assert "資料準備中" in call_args_str
+
+
+@pytest.mark.asyncio
+async def test_random_command_handles_network_error():
+    bot = _make_bot()
+    bot.api.get_random_problem.side_effect = ApiNetworkError("timeout")
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction)
+
+    call_args_str = str(interaction.followup.send.call_args)
+    assert "連線失敗" in call_args_str
+
+
+@pytest.mark.asyncio
+async def test_random_command_handles_rate_limit():
+    bot = _make_bot()
+    bot.api.get_random_problem.side_effect = ApiRateLimitError(5.0)
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction)
+
+    call_args_str = str(interaction.followup.send.call_args)
+    assert "頻率過高" in call_args_str
+
+
+@pytest.mark.asyncio
+async def test_random_command_handles_generic_api_error():
+    bot = _make_bot()
+    bot.api.get_random_problem.side_effect = ApiError(500, "Internal Server Error")
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction)
+
+    call_args_str = str(interaction.followup.send.call_args)
+    assert "查詢失敗" in call_args_str
+
+
+@pytest.mark.asyncio
+async def test_random_command_rating_same_min_max():
+    bot = _make_bot()
+    bot.api.get_random_problem.return_value = _sample_problem()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.random_command.callback(cog, interaction, rating_min=1500, rating_max=1500)
+
+    bot.api.get_random_problem.assert_called_once_with(difficulty=None, tags=None, rating_min=1500, rating_max=1500)


### PR DESCRIPTION
## Summary

- add `/random` slash command that fetches a random LeetCode problem with optional difficulty, tags, and rating-range filters
- add `get_random_problem()` to `OjApiClient` using a two-call strategy (count → random page → fetch item) with TOCTOU fallback when the selected page comes back empty
- reuse existing UI components (`create_problem_embed`, `create_problem_view`) and the unified `problem|{source}|{id}|{action}` button routing for consistent display and interaction
- add mention-injection protection on public no-result replies and standard error handling matching other slash commands

## Changes

- `src/bot/api_client.py`
  - add `get_random_problem()` with filter params, rating auto-swap, and empty-page fallback to page=1

- `src/bot/cogs/slash_commands_cog.py`
  - add `/random` command with `difficulty`, `tags`, `rating_min`, `rating_max`, `public` parameters
  - escape user-provided `tags` in no-result messages and disable mentions on public replies

- `tests/test_random_command.py`
  - 21 tests covering two-call strategy, filter passing, rating swap, TOCTOU fallback, error propagation, command delivery, public flag, mention safety, and API error handling

- `openspec/specs/slash-commands/spec.md`
  - sync /random requirements (filter handling, rating validation, API method, UI reuse)

## Test plan

- [x] `uv run --extra dev pytest` — 131 tests passed
- [x] `uv run ruff check` — lint clean
- [ ] Discord manual: `/random` returns a problem with interactive buttons
- [ ] Discord manual: `/random difficulty:Medium` filters correctly
- [ ] Discord manual: `/random tags:Array rating_min:1500 rating_max:2000` filters correctly
- [ ] Discord manual: no-match filters show filter summary in error message