### PR TITLE
🐛 fix(i18n): localize /random command and fix review findings

### DIFF
--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -103,13 +103,13 @@ class SlashCommandsCog(commands.Cog):
 
     # ── /random ────────────────────────────────────────────────────────
 
-    @app_commands.command(name="random", description="隨機取得一道 LeetCode 題目")
+    @app_commands.command(name="random", description=app_commands.locale_str("random.description"))
     @app_commands.describe(
-        difficulty="難度篩選",
-        tags="標籤篩選 (例如: Array)",
-        rating_min="最低評分",
-        rating_max="最高評分",
-        public="是否公開顯示回覆 (預設為私密回覆)",
+        difficulty=app_commands.locale_str("random.difficulty"),
+        tags=app_commands.locale_str("random.tags"),
+        rating_min=app_commands.locale_str("random.rating_min"),
+        rating_max=app_commands.locale_str("random.rating_max"),
+        public=app_commands.locale_str("random.public"),
     )
     @app_commands.choices(
         difficulty=[
@@ -127,6 +127,9 @@ class SlashCommandsCog(commands.Cog):
         rating_max: int = None,
         public: bool = False,
     ):
+        locale = _get_locale(self.bot, interaction)
+        i18n = self.bot.i18n
+
         if rating_min is not None and rating_max is not None and rating_min > rating_max:
             rating_min, rating_max = rating_max, rating_min
 
@@ -146,12 +149,12 @@ class SlashCommandsCog(commands.Cog):
                 if tags:
                     filters.append(f"tags:{discord.utils.escape_markdown(tags)}")
                 if rating_min is not None or rating_max is not None:
-                    r_min = str(rating_min) if rating_min is not None else "不限"
-                    r_max = str(rating_max) if rating_max is not None else "不限"
+                    r_min = str(rating_min) if rating_min is not None else "\u221e"
+                    r_max = str(rating_max) if rating_max is not None else "\u221e"
                     filters.append(f"rating:{r_min}-{r_max}")
-                filter_text = ", ".join(filters) if filters else "無篩選條件"
+                filter_text = ", ".join(filters) if filters else i18n.t("errors.validation.random_no_filter", locale)
                 await interaction.followup.send(
-                    f"沒有找到符合 {filter_text} 的題目，請調整篩選條件後重試。",
+                    i18n.t("errors.validation.random_not_found", locale, filters=filter_text),
                     ephemeral=True,
                     allowed_mentions=discord.AllowedMentions.none(),
                 )
@@ -165,24 +168,25 @@ class SlashCommandsCog(commands.Cog):
                 domain=domain,
                 is_daily=False,
                 user=interaction.user,
+                locale=locale,
             )
-            view = await create_problem_view(problem_info=problem, bot=self.bot, domain=domain)
+            view = await create_problem_view(problem_info=problem, bot=self.bot, domain=domain, locale=locale)
             await interaction.followup.send(embed=embed, view=view, ephemeral=not public)
             self.logger.info("Sent random problem to user %s", interaction.user.name)
 
         except ApiProcessingError:
-            await interaction.followup.send("⏳ 資料準備中，請稍後重試。", ephemeral=not public)
+            await send_api_error(interaction, "processing", self.bot, ephemeral=not public)
         except ApiNetworkError:
-            await interaction.followup.send("🔌 API 連線失敗，請稍後重試。", ephemeral=not public)
+            await send_api_error(interaction, "network", self.bot, ephemeral=not public)
         except ApiRateLimitError:
-            await interaction.followup.send("⏱️ 請求頻率過高，請稍後重試。", ephemeral=not public)
+            await send_api_error(interaction, "rate_limit", self.bot, ephemeral=not public)
         except ApiError as e:
             self.logger.error("API error in random command: %s", e)
-            await interaction.followup.send("❌ 查詢失敗，請稍後重試。", ephemeral=not public)
+            await send_api_error(interaction, "generic", self.bot, ephemeral=not public)
         except Exception as e:
             self.logger.error("Error in random_command: %s", e, exc_info=True)
             await interaction.followup.send(
-                "❌ 隨機題目時發生未預期錯誤，請稍後重試。",
+                i18n.t("errors.validation.random_error", locale),
                 ephemeral=not public,
                 allowed_mentions=discord.AllowedMentions.none(),
             )
@@ -368,6 +372,13 @@ class SlashCommandsCog(commands.Cog):
         clear_role=app_commands.locale_str("config.clear_role"),
         language=app_commands.locale_str("config.language"),
         reset=app_commands.locale_str("config.reset"),
+    )
+    @app_commands.choices(
+        language=[
+            app_commands.Choice(name="繁體中文", value="zh-TW"),
+            app_commands.Choice(name="English", value="en-US"),
+            app_commands.Choice(name="简体中文", value="zh-CN"),
+        ]
     )
     @app_commands.rename(post_time="time")
     async def config_command(
@@ -564,11 +575,6 @@ class SlashCommandsCog(commands.Cog):
     async def config_timezone_autocomplete(self, interaction: discord.Interaction, current: str):
         lowered = current.lower()
         return [app_commands.Choice(name=tz, value=tz) for tz in self._TZ_CHOICES if lowered in tz.lower()][:25]
-
-    @config_command.autocomplete("language")
-    async def config_language_autocomplete(self, interaction: discord.Interaction, current: str):
-        lowered = current.lower()
-        return [c for c in self._LANGUAGE_CHOICES if lowered in c.name.lower() or lowered in c.value.lower()]
 
     @config_command.error
     async def config_command_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):

--- a/src/bot/i18n/locales/en-US.json
+++ b/src/bot/i18n/locales/en-US.json
@@ -24,7 +24,10 @@
       "description_too_long": "The problem description is too long, displaying it as an embed.",
       "similar_not_found": "No similar problems found.",
       "no_query_provided": "Please provide at least a problem description (query) or problem ID (problem).",
-      "invalid_limit": "Limit must be at least 1."
+      "invalid_limit": "Limit must be at least 1.",
+      "random_not_found": "No problems found matching {filters}. Please adjust your filters and try again.",
+      "random_no_filter": "no filters",
+      "random_error": "❌ An unexpected error occurred while fetching a random problem. Please try again."
     },
     "unexpected": "An unexpected error occurred: {error}",
     "config": {
@@ -179,6 +182,14 @@
       "problem": "Problem ID or URL (e.g., 1, atcoder:abc100_a)",
       "top_k": "Number of results to return (default 5)",
       "source": "Problem source (leave empty for all)",
+      "public": "Whether to show the reply publicly (default: private)"
+    },
+    "random": {
+      "description": "Get a random LeetCode problem",
+      "difficulty": "Difficulty filter",
+      "tags": "Tag filter (e.g., Array)",
+      "rating_min": "Minimum rating",
+      "rating_max": "Maximum rating",
       "public": "Whether to show the reply publicly (default: private)"
     }
   },

--- a/src/bot/i18n/locales/zh-CN.json
+++ b/src/bot/i18n/locales/zh-CN.json
@@ -24,7 +24,10 @@
       "description_too_long": "由于题目内容过长，使用嵌入式消息的方式显示。",
       "similar_not_found": "找不到相似题目。",
       "no_query_provided": "请至少输入题目描述 (query) 或题目编号 (problem)。",
-      "invalid_limit": "数量至少为 1"
+      "invalid_limit": "数量至少为 1",
+      "random_not_found": "没有找到符合 {filters} 的题目，请调整筛选条件后重试。",
+      "random_no_filter": "无筛选条件",
+      "random_error": "❌ 随机题目时发生未预期错误，请稍后重试。"
     },
     "unexpected": "发生未预期错误：{error}",
     "config": {
@@ -179,6 +182,14 @@
       "problem": "既有题目编号或网址 (例如: 1, atcoder:abc100_a)",
       "top_k": "返回结果数量 (默认 5)",
       "source": "题库来源 (留空为全部)",
+      "public": "是否公开显示回复 (默认为私密回复)"
+    },
+    "random": {
+      "description": "随机获取一道 LeetCode 题目",
+      "difficulty": "难度筛选",
+      "tags": "标签筛选 (例如: Array)",
+      "rating_min": "最低评分",
+      "rating_max": "最高评分",
       "public": "是否公开显示回复 (默认为私密回复)"
     }
   },

--- a/src/bot/i18n/locales/zh-TW.json
+++ b/src/bot/i18n/locales/zh-TW.json
@@ -24,7 +24,10 @@
       "description_too_long": "由於題目內容過長，使用嵌入式訊息的方式顯示。",
       "similar_not_found": "找不到相似題目。",
       "no_query_provided": "請至少輸入題目敘述 (query) 或題目編號 (problem)",
-      "invalid_limit": "數量至少為 1"
+      "invalid_limit": "數量至少為 1",
+      "random_not_found": "沒有找到符合 {filters} 的題目，請調整篩選條件後重試。",
+      "random_no_filter": "無篩選條件",
+      "random_error": "❌ 隨機題目時發生未預期錯誤，請稍後重試。"
     },
     "unexpected": "發生未預期錯誤：{error}",
     "config": {
@@ -159,6 +162,14 @@
       "problem": "既有題目編號或網址 (例如: 1, atcoder:abc100_a)",
       "top_k": "返回結果數量 (預設 5)",
       "source": "題庫來源 (留空為全部)",
+      "public": "是否公開顯示回覆 (預設為私密回覆)"
+    },
+    "random": {
+      "description": "隨機取得一道 LeetCode 題目",
+      "difficulty": "難度篩選",
+      "tags": "標籤篩選 (例如: Array)",
+      "rating_min": "最低評分",
+      "rating_max": "最高評分",
       "public": "是否公開顯示回覆 (預設為私密回覆)"
     }
   },

--- a/src/bot/i18n/service.py
+++ b/src/bot/i18n/service.py
@@ -24,6 +24,7 @@ class I18nService:
         self._supported_locales = set(supported_locales)
         self._locales_dir = locales_dir or _LOCALES_DIR
         self._strings: dict[str, dict[str, Any]] = {}
+        self._db = None
         self.load_locales()
 
     def load_locales(self) -> None:

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -214,10 +214,14 @@ def _join_lines_with_ellipsis(lines: List[str], *, max_length: int) -> tuple[str
     return "\n".join(rendered_lines), len(rendered_lines), False
 
 
-def _build_similar_result_line(index: int, result_item: Dict[str, Any]) -> str:
-    source = _normalize_similar_result_segment(result_item.get("source"), "unknown")
+def _build_similar_result_line(
+    index: int, result_item: Dict[str, Any], *, locale: str = "zh-TW", bot: Any = None
+) -> str:
+    i18n = bot.i18n if bot else None
+    unknown_source = i18n.t("ui.embed.source_label", locale) if i18n else "unknown"
+    source = _normalize_similar_result_segment(result_item.get("source"), unknown_source)
     problem_id = _normalize_similar_result_segment(result_item.get("id"), "?")
-    title = _normalize_similar_result_segment(result_item.get("title"), "Unknown problem")
+    title = _normalize_similar_result_segment(result_item.get("title"), "")
     emoji = get_source_difficulty_emoji(source, result_item.get("difficulty"))
     separator = ". " if source == "leetcode" else ": "
     problem_text = f"{problem_id}{separator}{title}"
@@ -246,7 +250,10 @@ def _build_similar_results_embed(
         field_name = i18n.t("ui.embed.base_problem", locale) if i18n else "Base Problem"
         embed.add_field(name=field_name, value=f"{base_source}:{base_id}", inline=False)
 
-    lines = [_build_similar_result_line(index, item) for index, item in enumerate(result.get("results") or [], 1)]
+    lines = [
+        _build_similar_result_line(index, item, locale=locale, bot=bot)
+        for index, item in enumerate(result.get("results") or [], 1)
+    ]
     was_truncated = False
 
     for i in range(0, len(lines), PROBLEMS_PER_FIELD):

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -272,11 +272,11 @@ async def test_random_command_no_results_shows_filter_summary():
     await cog.random_command.callback(cog, interaction, difficulty="Hard", tags="DP", rating_min=1500, rating_max=2000)
 
     _, kwargs = interaction.followup.send.call_args
-    call_str = str(interaction.followup.send.call_args)
-    assert "difficulty:Hard" in call_str
-    assert "tags:DP" in call_str
-    assert "rating:1500-2000" in call_str
     assert kwargs["ephemeral"] is True
+    # i18n.t mock returns the key; verify the key was used
+    bot.i18n.t.assert_any_call(
+        "errors.validation.random_not_found", "zh-TW", filters="difficulty:Hard, tags:DP, rating:1500-2000"
+    )
 
 
 @pytest.mark.asyncio
@@ -301,8 +301,10 @@ async def test_random_command_no_results_no_filters():
 
     await cog.random_command.callback(cog, interaction)
 
-    call_args_str = str(interaction.followup.send.call_args)
-    assert "無篩選條件" in call_args_str
+    bot.i18n.t.assert_any_call("errors.validation.random_no_filter", "zh-TW")
+    bot.i18n.t.assert_any_call(
+        "errors.validation.random_not_found", "zh-TW", filters="errors.validation.random_no_filter"
+    )
 
 
 @pytest.mark.asyncio
@@ -330,8 +332,8 @@ async def test_random_command_handles_api_processing_error():
 
     await cog.random_command.callback(cog, interaction)
 
-    call_args_str = str(interaction.followup.send.call_args)
-    assert "資料準備中" in call_args_str
+    # send_api_error delegates to i18n.t; verify the key was used
+    bot.i18n.t.assert_any_call("errors.api.processing", "zh-TW")
 
 
 @pytest.mark.asyncio
@@ -343,8 +345,7 @@ async def test_random_command_handles_network_error():
 
     await cog.random_command.callback(cog, interaction)
 
-    call_args_str = str(interaction.followup.send.call_args)
-    assert "連線失敗" in call_args_str
+    bot.i18n.t.assert_any_call("errors.api.network", "zh-TW")
 
 
 @pytest.mark.asyncio
@@ -356,8 +357,7 @@ async def test_random_command_handles_rate_limit():
 
     await cog.random_command.callback(cog, interaction)
 
-    call_args_str = str(interaction.followup.send.call_args)
-    assert "頻率過高" in call_args_str
+    bot.i18n.t.assert_any_call("errors.api.rate_limit", "zh-TW")
 
 
 @pytest.mark.asyncio
@@ -369,8 +369,7 @@ async def test_random_command_handles_generic_api_error():
 
     await cog.random_command.callback(cog, interaction)
 
-    call_args_str = str(interaction.followup.send.call_args)
-    assert "查詢失敗" in call_args_str
+    bot.i18n.t.assert_any_call("errors.api.generic", "zh-TW")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Localize `/random` command: `locale_str()` decorator, `t()` runtime strings, `send_api_error()` for errors
- Add `commands.random.*` keys to all 3 locale files (zh-TW, en-US, zh-CN)
- Pass locale to `create_problem_embed()` / `create_problem_view()` from `random_command`
- Switch `/config language` from autocomplete to `@app_commands.choices` per spec D8
- Initialize `self._db = None` in `I18nService.__init__`
- Add locale support to `_build_similar_result_line`

## Test plan
- [x] 132 tests passed, 0 failed
- [x] ruff lint + format clean
- [x] Locale key parity verified across zh-TW, en-US, zh-CN