### PR TITLE
🐛 fix(i18n): shorten en-US description to fix command sync failure

### DIFF
--- a/src/bot/i18n/locales/en-US.json
+++ b/src/bot/i18n/locales/en-US.json
@@ -141,12 +141,12 @@
   "commands": {
     "daily": {
       "description": "Get LeetCode Daily Challenge (LCUS)",
-      "date": "Query daily challenge for a specific date (YYYY-MM-DD format), defaults to today, earliest 2020-04-01",
+      "date": "Query daily challenge for a specific date (YYYY-MM-DD), defaults to today, earliest 2020-04-01",
       "public": "Whether to show the reply publicly (default: private)"
     },
     "daily_cn": {
       "description": "Get LeetCode Daily Challenge (LCCN)",
-      "date": "Query daily challenge for a specific date (YYYY-MM-DD format), defaults to today, earliest 2020-04-01",
+      "date": "Query daily challenge for a specific date (YYYY-MM-DD), defaults to today, earliest 2020-04-01",
       "public": "Whether to show the reply publicly (default: private)"
     },
     "problem": {


### PR DESCRIPTION
## Summary

- Shorten `commands.daily.date` and `commands.daily_cn.date` en-US locale strings from 101 to 94 characters to comply with Discord's 100-character parameter description limit
- This was causing `bot.tree.sync()` to fail with HTTP 400 (error code 50035), which prevented **all** slash commands from syncing — including `/random`

## Root Cause

```
Failed to sync commands: Failed to upload commands to Discord (HTTP status 400, error code 50035)
In command 'daily' → parameter 'date'
  description_localizations.en-US: Must be between 1 and 100 in length.
```

## Test plan

- [x] en-US `daily.date` and `daily_cn.date` strings verified at 94 characters (under 100 limit)
- [x] Scanned all en-US locale strings: no other command/parameter descriptions exceed 100 characters
- [x] Discord manual: bot restarts with `Synced N commands` in logs (no more HTTP 400)
- [x] Discord manual: `/random` appears in command list and works correctly