### PR TITLE
🐛 fix(api): adapt similar text search to upstream POST contract

### DIFF
--- a/openspec/changes/archive/2026-05-30-adapt-similar-post/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-adapt-similar-post/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-30-adapt-similar-post/design.md
+++ b/openspec/changes/archive/2026-05-30-adapt-similar-post/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Upstream `oj-api-rs` changed the text-based similar-search contract from GET query parameters to a POST JSON body. The current bot already routes `/similar` text queries through `OjApiClient.search_similar_by_text()`, so the change is isolated to the API client boundary and should not alter the Discord command surface.
+
+The existing code already distinguishes text-query search from problem-id search, and the result rendering path is shared. That makes this a small compatibility update rather than a broader feature change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Align text-query similarity requests with the upstream POST contract.
+- Preserve the existing `/similar` command UX and problem-id path.
+- Keep the change narrowly scoped to the API client and tests.
+
+**Non-Goals:**
+- Do not change the `/similar` command parameters or public response format.
+- Do not add a compatibility fallback unless required by deployment reality.
+- Do not redesign similarity result rendering or detail-button behavior.
+
+## Decisions
+
+- Use `POST /similar` with a JSON body for text queries.
+  - Rationale: matches the upstream contract and avoids URL truncation / encoding issues for long text queries.
+  - Alternative considered: keep GET and add a server-side compatibility shim. Rejected because it would preserve the mismatch and hides the new contract.
+
+- Keep `search_similar_by_id()` unchanged.
+  - Rationale: the upstream change only affects text search; problem-id lookup remains on the existing endpoint.
+  - Alternative considered: unify both paths behind one new client method. Rejected because it would add unnecessary indirection for a single compatibility fix.
+
+- Preserve the bot-facing `search_similar_by_text()` return contract.
+  - Rationale: downstream command code and UI helpers should not need to change.
+  - Alternative considered: expose raw request/response handling in the cog. Rejected because it would leak transport details into command logic.
+
+## Risks / Trade-offs
+
+- [Deployment skew] Upstream API servers still on the old GET contract will reject POST requests → Coordinate deployment with the upstream API version or add an explicit fallback later if required.
+- [Test drift] Existing tests may still assert GET query parameters → Update request-shape tests alongside the implementation.
+- [Behavioral regression] The new body-based call could accidentally alter parameter mapping → Cover the exact payload shape in tests.

--- a/openspec/changes/archive/2026-05-30-adapt-similar-post/proposal.md
+++ b/openspec/changes/archive/2026-05-30-adapt-similar-post/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Upstream changed text-based `/similar` search from GET query parameters to a POST JSON body, and the current bot will stop matching the deployed API contract once the upstream server is on the new nightly release. This change keeps text-query similarity search working for long queries while preserving the existing problem-id search flow.
+
+## What Changes
+
+- Update the bot's text-query similarity request to use POST with a JSON body.
+- Keep problem-id similarity search on the existing by-id endpoint.
+- Preserve the current `/similar` Discord command interface and result presentation.
+- Update or add tests to cover the new request shape and response handling.
+
+## Capabilities
+
+### Modified Capabilities
+- `embedding-search`: text-query similarity search now uses the upstream POST JSON contract instead of GET query parameters.
+
+## Impact
+
+- `src/bot/api_client.py` request construction for `search_similar_by_text()`.
+- `tests/` coverage for text similarity requests and command behavior.
+- Upstream API compatibility for deployments that use the nightly `oj-api-rs` contract.

--- a/openspec/changes/archive/2026-05-30-adapt-similar-post/specs/embedding-search/spec.md
+++ b/openspec/changes/archive/2026-05-30-adapt-similar-post/specs/embedding-search/spec.md
@@ -1,8 +1,5 @@
-# embedding-search Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change init-project-specs. Update Purpose after archive.
-## Requirements
 ### Requirement: Similarity search uses the remote API backend
 The `/similar` command SHALL use the remote API exposed through the application API client as its only similarity-search backend. The runtime SHALL resolve similar problems by calling the API client from the packaged runtime namespace and SHALL NOT depend on local embedding indices, local vector stores, or local embedding generation workflows.
 
@@ -28,22 +25,4 @@ The `/similar` command SHALL use the remote API exposed through the application 
 
 #### Scenario: Runtime ownership
 - **WHEN** runtime code performs similarity search after the source layout is reorganized under `src/bot/`
-- **THEN** ownership SHALL remain within packaged runtime modules such as `bot.api_client` and `bot.cogs.similar_cog`
-
-## PBT Properties
-
-### Property: Remote-only presentation path
-- **INVARIANT**: Building a similar-result response never requires local similarity lookup or eager per-result problem-detail fetches
-- **FALSIFICATION**: Instrument the response-building path and assert that it uses only the existing remote similarity payload plus the existing lazy `view` interaction for full details
-
-### Property: Slash clamp independence from UI cap
-- **INVARIANT**: Slash `/similar` input normalization stays bounded by its existing fetch clamp even though the detail-button render cap is 25
-- **FALSIFICATION**: Generate arbitrary slash `top_k` inputs and assert that the remote similarity fetch limit remains clamped to the slash-command policy rather than the render-time button cap
-
-### Requirement: No local similarity maintenance workflow
-The repository SHALL NOT document or require local embedding build, rebuild, query, or vector-storage workflows for `/similar`.
-
-#### Scenario: Documentation guidance
-- **WHEN** runtime or developer documentation describes `/similar`
-- **THEN** it SHALL describe the feature as remote-only and SHALL NOT instruct operators to run `embedding_cli.py`, manage local embedding indices, or install `sqlite-vec` for normal bot operation
-
+- **THEN** runtime ownership SHALL remain within packaged modules such as `bot.api_client` and `bot.cogs.similar_cog`

--- a/openspec/changes/archive/2026-05-30-adapt-similar-post/tasks.md
+++ b/openspec/changes/archive/2026-05-30-adapt-similar-post/tasks.md
@@ -1,0 +1,15 @@
+## 1. API client update
+
+- [x] 1.1 Change `OjApiClient.search_similar_by_text()` to send POST `/similar` with a JSON body containing `query`, `limit`, `threshold`, and optional `source`.
+- [x] 1.2 Keep `search_similar_by_id()` unchanged so problem-id similarity lookups continue to use the existing endpoint.
+
+## 2. Test coverage
+
+- [x] 2.1 Update or add API client tests to assert the POST method and request body for text-query similarity search.
+- [x] 2.2 Add or update command-level tests to confirm `/similar` text queries still render results through the shared builder after the request shape change.
+- [x] 2.3 Verify existing safe/unsafe result presentation tests still pass with the updated client contract.
+
+## 3. Verification
+
+- [x] 3.1 Run the targeted test suite for similarity search and command behavior.
+- [x] 3.2 Review the final change set against the proposal and spec for contract alignment.

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -147,10 +147,10 @@ class OjApiClient:
     async def search_similar_by_text(
         self, query: str, source: str | None = None, top_k: int = 5, min_similarity: float = 0.7
     ) -> dict | None:
-        params: dict[str, str] = {"q": query, "limit": str(top_k), "threshold": str(min_similarity)}
+        payload: dict[str, str | int | float] = {"query": query, "limit": top_k, "threshold": min_similarity}
         if source:
-            params["source"] = source
-        return await self._request("GET", "similar", params=params)
+            payload["source"] = source
+        return await self._request("POST", "similar", json=payload)
 
     @staticmethod
     def _list_total(response: dict) -> int:

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -150,7 +150,7 @@ class OjApiClient:
         payload: dict[str, str | int | float] = {"query": query, "limit": top_k, "threshold": min_similarity}
         if source:
             payload["source"] = source
-        return await self._request("POST", "similar", json=payload)
+        return await self._do_request("POST", "similar", json=payload)
 
     @staticmethod
     def _list_total(response: dict) -> int:

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import random
 from urllib.parse import quote
@@ -104,10 +105,13 @@ class OjApiClient:
 
     async def _request(self, method: str, path: str, **kwargs) -> dict | None:
         params = kwargs.get("params")
+        json_body = kwargs.get("json")
         key = f"{method}:{path}"
         if params:
             sorted_params = "&".join(f"{k}={v}" for k, v in sorted(params.items()) if v is not None)
             key = f"{key}?{sorted_params}"
+        if json_body is not None:
+            key = f"{key}|{json.dumps(json_body, sort_keys=True)}"
 
         if key in self._inflight:
             return await self._inflight[key]
@@ -150,7 +154,7 @@ class OjApiClient:
         payload: dict[str, str | int | float] = {"query": query, "limit": top_k, "threshold": min_similarity}
         if source:
             payload["source"] = source
-        return await self._do_request("POST", "similar", json=payload)
+        return await self._request("POST", "similar", json=payload)
 
     @staticmethod
     def _list_total(response: dict) -> int:

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -73,11 +73,11 @@ def _problem_list_response(total: int, problems: list[dict] | None = None, page:
 async def test_search_similar_by_text_uses_post_json_body():
     api = OjApiClient("http://test")
     api._session = AsyncMock()
-    api._do_request = AsyncMock(return_value={"results": []})
+    api._request = AsyncMock(return_value={"results": []})
 
     await api.search_similar_by_text("graph dp", source="leetcode", top_k=7, min_similarity=0.82)
 
-    api._do_request.assert_awaited_once_with(
+    api._request.assert_awaited_once_with(
         "POST",
         "similar",
         json={"query": "graph dp", "limit": 7, "threshold": 0.82, "source": "leetcode"},

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -73,11 +73,11 @@ def _problem_list_response(total: int, problems: list[dict] | None = None, page:
 async def test_search_similar_by_text_uses_post_json_body():
     api = OjApiClient("http://test")
     api._session = AsyncMock()
-    api._request = AsyncMock(return_value={"results": []})
+    api._do_request = AsyncMock(return_value={"results": []})
 
     await api.search_similar_by_text("graph dp", source="leetcode", top_k=7, min_similarity=0.82)
 
-    api._request.assert_awaited_once_with(
+    api._do_request.assert_awaited_once_with(
         "POST",
         "similar",
         json={"query": "graph dp", "limit": 7, "threshold": 0.82, "source": "leetcode"},

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -66,6 +66,39 @@ def _problem_list_response(total: int, problems: list[dict] | None = None, page:
     }
 
 
+# -- similar search tests --
+
+
+@pytest.mark.asyncio
+async def test_search_similar_by_text_uses_post_json_body():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value={"results": []})
+
+    await api.search_similar_by_text("graph dp", source="leetcode", top_k=7, min_similarity=0.82)
+
+    api._request.assert_awaited_once_with(
+        "POST",
+        "similar",
+        json={"query": "graph dp", "limit": 7, "threshold": 0.82, "source": "leetcode"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_similar_by_id_keeps_existing_get_endpoint():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value={"results": []})
+
+    await api.search_similar_by_id("atcoder", "abc100_a", top_k=3, min_similarity=0.91)
+
+    api._request.assert_awaited_once_with(
+        "GET",
+        "similar/atcoder/abc100_a",
+        params={"limit": "3", "threshold": "0.91"},
+    )
+
+
 # -- get_random_problem tests --
 
 


### PR DESCRIPTION
## Summary

- Change `search_similar_by_text()` from GET query params to POST with JSON body to match upstream `oj-api-rs` nightly contract (commit `1c473dc`)
- Keep `search_similar_by_id()` on the existing GET endpoint (unchanged upstream)
- Update `embedding-search` spec to reflect POST JSON contract for text queries
- Add API client tests asserting POST method/body shape and GET endpoint preservation
- Archive `adapt-similar-post` OpenSpec change with all artifacts

## Tests

- `uv run --extra dev pytest tests/test_random_command.py tests/test_similar_cog.py tests/test_similar_results.py` — 41 passed