### PR TITLE
✨ feat(random): add tags autocomplete with TTL cache and startup preload

### DIFF
--- a/openspec/changes/archive/2026-05-30-random-tags-autocomplete/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-random-tags-autocomplete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/archive/2026-05-30-random-tags-autocomplete/design.md
+++ b/openspec/changes/archive/2026-05-30-random-tags-autocomplete/design.md
@@ -1,0 +1,84 @@
+## Context
+
+目前 `/random` 指令的 `tags` 參數是自由文字字串，無任何 autocomplete 輔助。`GET /api/v1/tags/{source}` 端點可回傳指定來源的有效標籤清單（字串陣列），需要 bearer auth。Discord.py 提供 `@<command>.autocomplete("param")` decorator 可為單一參數加上動態 autocomplete，且可以從 `interaction.namespace` 取得使用者已選擇的其他參數值。
+
+現有前例：`@problem_command.autocomplete("domain")`（`slash_commands_cog.py:343`），但該案例是靜態資料。本次需要的是**根據 source 動態查詢**的 autocomplete。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 當使用者在 `/random` 選擇 source 後，在 `tags` 欄位輸入時自動顯示該來源的有效標籤建議
+- 透過 TTL 快取避免重複請求 API，減少延遲與 API 負載
+- API 失敗時 graceful degradation（回傳空清單或 stale cache），不影響主指令流程
+
+**Non-Goals:**
+- 不為 `difficulty` 或 `source` 參數增加 autocomplete（已是靜態 choices）
+- 不支援跨來源的複合標籤查詢（API 本身以單一 source 為單位）
+- 不實作管理員手動刷新快取的功能
+
+## Decisions
+
+### 1. Tags 快取放在 `OjApiClient`
+
+**選擇**：在 `OjApiClient` 內部實作 `_tags_cache` 字典 + `get_tags_cached()` 方法。
+
+**替代方案**：獨立的 `TagCache` 類別或 module-level global。
+
+**理由**：Tags 資料與 API 端點緊密耦合，放在 API client 內部是最小驚訝原則。不需要引入新的模組或依賴注入。既有 `_inflight` dedup 機制也已在 `OjApiClient` 中。
+
+### 2. TTL 24 小時 + stale-while-revalidate
+
+**選擇**：快取 24 小時（86400 秒）。過期後若 API 呼叫失敗，fallback 到 stale cache。
+
+```
+get_tags_cached(source):
+    cached = _tags_cache.get(source)   # (timestamp, tags)
+    if cached and now - cached.ts < TTL:
+        return cached.tags
+    try:
+        tags = await get_tags(source)
+        _tags_cache[source] = (now, tags)
+        return tags
+    except:
+        if cached:
+            return cached.tags   # stale fallback
+        return []                # no cache at all
+```
+
+**理由**：標籤變動頻率極低（數月才可能新增/刪除），24 小時 TTL 足夠保守。stale fallback 確保即使 API 暫時故障，autocomplete 仍能運作。
+
+### 3. 透過 `interaction.namespace` 讀取當前 source
+
+**選擇**：在 autocomplete callback 中讀取 `interaction.namespace.source` 來決定查詢哪個來源的標籤。預設值為 `"leetcode"`。
+
+```python
+@random_command.autocomplete("tags")
+async def random_tags_autocomplete(self, interaction, current):
+    source = (interaction.namespace.source if interaction.namespace else None) or "leetcode"
+    tags = await self.bot.api.get_tags_cached(source)
+    filtered = [t for t in tags if current.lower() in t.lower()]
+    return [Choice(name=t, value=t) for t in filtered[:25]]
+```
+
+**替代方案**：為每個 source 預先建立靜態 choices list。
+
+**理由**：靜態 choices 無法隨 source 變動（Discord 的 `@app_commands.choices` 是註冊時就固定的）。`interaction.namespace` 是 Discord.py 標準機制，讓 autocomplete 能回應使用者已選的其他參數。
+
+### 4. Fire-and-forget 啟動預載入
+
+**選擇**：在 `on_ready` 中對 `["leetcode", "codeforces"]` 發起 `asyncio.create_task(get_tags_cached())`，不等待結果。
+
+**理由**：這兩個是最常用的來源，預載入可確保首次 autocomplete 無網路延遲。Fire-and-forget 不阻塞 bot 啟動。其他來源（atcoder、luogu、spoj）在使用者首次選用時 lazy load。
+
+### 5. Autocomplete 失敗不回報錯誤給使用者
+
+**選擇**：API 失敗時回傳空 `list[Choice]`，不顯示任何錯誤訊息。
+
+**理由**：Autocomplete 是輔助功能，失敗時使用者仍可手動輸入 tags。顯示錯誤會造成不必要的干擾。
+
+## Risks / Trade-offs
+
+- **[快取不一致]** 若 upstream 新增/刪除標籤，使用者可能在 24 小時內看到過期的 autocomplete 建議 → 影響極低：標籤變更極罕見，且使用者仍可手動輸入新的標籤名稱
+- **[記憶體]** 每個來源的快取約數十到數百個字串，所有來源總計 < 50KB → 可忽略
+- **[Rate limit]** 預載入時同時發兩個 API request → OjApiClient 內建 `_inflight` dedup，不會重複請求同一端點
+- **[冷啟動延遲]** 非熱門來源（如 spoj）在首次 autocomplete 時才發 API 請求，可能有 ~200ms 延遲 → 可接受，且此類來源使用頻率低

--- a/openspec/changes/archive/2026-05-30-random-tags-autocomplete/proposal.md
+++ b/openspec/changes/archive/2026-05-30-random-tags-autocomplete/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+目前 `/random` 指令的 `tags` 參數是自由文字輸入，使用者需要憑記憶或猜測來輸入標籤名稱（如 "Array"、"Dynamic Programming"），容易打錯字或根本不知道有哪些可用標籤。而 upstream API 已提供 `GET /api/v1/tags/{source}` 端點可查詢每個來源的有效標籤清單。利用此端點為 `tags` 參數加上 autocomplete，能大幅提升使用者體驗並減少輸入錯誤。
+
+## What Changes
+
+- 在 `OjApiClient` 新增 `get_tags(source)` 方法，呼叫 `GET /api/v1/tags/{source}` 取得標籤清單
+- 在 `OjApiClient` 新增 TTL 快取層 (`get_tags_cached`)，避免重複請求 API，並在 API 失敗時 graceful degradation
+- 為 `/random` 指令的 `tags` 參數加上 `@autocomplete` callback，根據使用者當前選擇的 `source` 動態提供標籤建議
+- 啟動時可選地預載 `leetcode` 和 `codeforces` 的標籤，讓首次使用 autocomplete 時無延遲
+- 新增對應的測試覆蓋
+
+## Capabilities
+
+### New Capabilities
+
+- `tag-autocomplete`: 為 `/random` 指令的 `tags` 參數提供動態 autocomplete，根據選擇的題目來源（LeetCode、Codeforces 等）從 API 取得有效標籤清單，附帶 TTL 快取與錯誤容錯
+
+### Modified Capabilities
+
+- `slash-commands`: 新增 tags autocomplete 相關的 scenario（autocomplete 根據 source 動態載入、API 失敗時 fallback 為空清單、無 source 時預設 leetcode）
+
+## Impact
+
+- `src/bot/api_client.py` — 新增 `get_tags()` 和 `get_tags_cached()` 方法，以及 `_tags_cache` 內部狀態
+- `src/bot/cogs/slash_commands_cog.py` — 新增 `@random_command.autocomplete("tags")` callback
+- `src/bot/app.py` — 可選的啟動預載入邏輯（`on_ready` 中 fire-and-forget）
+- `tests/test_random_command.py` — 新增 autocomplete 與 `get_tags` 方法的測試

--- a/openspec/changes/archive/2026-05-30-random-tags-autocomplete/specs/slash-commands/spec.md
+++ b/openspec/changes/archive/2026-05-30-random-tags-autocomplete/specs/slash-commands/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Random problem tags autocomplete
+The `/random` command's `tags` parameter SHALL support dynamic autocomplete that fetches valid tags from the upstream API based on the currently selected source.
+
+#### Scenario: Tags autocomplete appears when typing
+- **WHEN** a user runs `/random`, selects a source, and begins typing in the `tags` field
+- **THEN** the bot SHALL display up to 25 tag suggestions filtered by the typed input, fetched from the API for the currently selected source
+
+#### Scenario: Tags autocomplete defaults to leetcode source
+- **WHEN** a user begins typing in the `tags` field without having explicitly selected a source
+- **THEN** the autocomplete SHALL use "leetcode" as the default source for tag suggestions
+
+#### Scenario: Tags autocomplete updates when source changes
+- **WHEN** a user changes the source value and then types in the `tags` field
+- **THEN** the autocomplete SHALL fetch and display tags for the newly selected source
+
+#### Scenario: Tags autocomplete empty result on API failure
+- **WHEN** the tags API is unavailable during autocomplete
+- **THEN** the bot SHALL return an empty autocomplete list without showing an error message, allowing the user to type tags manually
+
+#### Scenario: Tags autocomplete handles no matches
+- **WHEN** the user's typed input does not match any tag for the selected source
+- **THEN** the bot SHALL return an empty autocomplete list (no choices displayed)

--- a/openspec/changes/archive/2026-05-30-random-tags-autocomplete/specs/tag-autocomplete/spec.md
+++ b/openspec/changes/archive/2026-05-30-random-tags-autocomplete/specs/tag-autocomplete/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Tags by source API method
+The `OjApiClient` SHALL provide a `get_tags(source)` method that retrieves the valid tag list for a given problem source via `GET /api/v1/tags/{source}`.
+
+#### Scenario: Successful tag retrieval
+- **WHEN** `get_tags("leetcode")` is called
+- **THEN** the method SHALL send a `GET /api/v1/tags/leetcode` request and return the response as a list of strings
+
+#### Scenario: Empty tag list
+- **WHEN** the API returns an empty array for a valid source
+- **THEN** the method SHALL return an empty list
+
+#### Scenario: Invalid source
+- **WHEN** the API returns a 400 status for an invalid source
+- **THEN** the method SHALL return an empty list without raising an exception
+
+#### Scenario: API error
+- **WHEN** the API returns a 500 status or network error
+- **THEN** the method SHALL propagate standard error types (ApiNetworkError, ApiError)
+
+### Requirement: TTL-cached tags access
+The `OjApiClient` SHALL provide a `get_tags_cached(source)` method that caches tag results with a 24-hour TTL and supports stale fallback on API failure.
+
+#### Scenario: Cache hit
+- **WHEN** `get_tags_cached("leetcode")` is called and a cached result exists within the TTL (86400 seconds)
+- **THEN** the method SHALL return the cached tags without making an API request
+
+#### Scenario: Cache miss triggers API call
+- **WHEN** `get_tags_cached("leetcode")` is called and no cached result exists
+- **THEN** the method SHALL call `get_tags("leetcode")`, cache the result with a timestamp, and return the tags
+
+#### Scenario: Expired cache with successful refresh
+- **WHEN** `get_tags_cached("leetcode")` is called and the cache is older than TTL
+- **THEN** the method SHALL attempt a fresh API call, update the cache on success, and return the fresh tags
+
+#### Scenario: Expired cache with failed refresh returns stale
+- **WHEN** `get_tags_cached("leetcode")` is called, the cache is older than TTL, and the API call fails
+- **THEN** the method SHALL log a warning and return the stale cached tags
+
+#### Scenario: No cache and API failure returns empty
+- **WHEN** `get_tags_cached("spoj")` is called, no cache exists, and the API call fails
+- **THEN** the method SHALL return an empty list without raising an exception
+
+### Requirement: Tags autocomplete callback
+The `/random` command SHALL provide a dynamic autocomplete for the `tags` parameter that fetches valid tags for the currently selected source.
+
+#### Scenario: Autocomplete with selected source
+- **WHEN** a user has selected source "LeetCode" and starts typing in the `tags` field
+- **THEN** the autocomplete SHALL fetch tags for "leetcode" and return up to 25 matching `Choice` objects filtered by the typed input (case-insensitive substring match)
+
+#### Scenario: Autocomplete with default source
+- **WHEN** a user starts typing in the `tags` field without explicitly selecting a source
+- **THEN** the autocomplete SHALL default to source "leetcode" and return matching tags for that source
+
+#### Scenario: Autocomplete with no matching tags
+- **WHEN** the user's input does not match any tags for the selected source
+- **THEN** the autocomplete SHALL return an empty list of choices (no error message)
+
+#### Scenario: Autocomplete API failure graceful degradation
+- **WHEN** the tags API fails (network error, server error) during autocomplete
+- **THEN** the autocomplete SHALL return an empty list of choices without displaying an error to the user
+
+#### Scenario: Source change updates autocomplete suggestions
+- **WHEN** a user changes the source from "LeetCode" to "Codeforces" and then types in the `tags` field
+- **THEN** the autocomplete SHALL fetch and return tags for "codeforces"
+
+### Requirement: Startup tag preloading
+The bot SHALL optionally preload tags for popular sources on startup to eliminate cold-start latency for the first autocomplete request.
+
+#### Scenario: Preload on ready
+- **WHEN** the bot fires the `on_ready` event
+- **THEN** the bot SHALL initiate fire-and-forget `get_tags_cached()` calls for "leetcode" and "codeforces" without blocking command sync or schedule initialization
+
+#### Scenario: Preload failure does not block startup
+- **WHEN** a preload API call fails
+- **THEN** the failure SHALL be logged at warning level and SHALL NOT prevent the bot from starting or serving autocomplete requests

--- a/openspec/changes/archive/2026-05-30-random-tags-autocomplete/tasks.md
+++ b/openspec/changes/archive/2026-05-30-random-tags-autocomplete/tasks.md
@@ -1,0 +1,22 @@
+## 1. API Client — Tags fetching
+
+- [x] 1.1 Add `get_tags(source)` method to `OjApiClient` that calls `GET /api/v1/tags/{source}` and returns `list[str]`
+- [x] 1.2 Add `_tags_cache: dict[str, tuple[float, list[str]]]` and `_TAGS_CACHE_TTL = 86400` to `OjApiClient`
+- [x] 1.3 Add `get_tags_cached(source)` method with TTL check, cache miss → API call → cache write, and stale fallback on error
+
+## 2. Autocomplete Callback
+
+- [x] 2.1 Add `@random_command.autocomplete("tags")` callback in `SlashCommandsCog`
+- [x] 2.2 Read current source from `interaction.namespace.source` (default `"leetcode"`) in the callback
+- [x] 2.3 Filter tags by `current` input (case-insensitive substring) and return up to 25 `Choice` objects
+
+## 3. Startup Preloading
+
+- [x] 3.1 In `on_ready` (app.py), fire-and-forget `get_tags_cached()` for `["leetcode", "codeforces"]` via `asyncio.create_task`
+- [x] 3.2 Ensure preload failures are logged at warning level and do not block startup
+
+## 4. Tests
+
+- [x] 4.1 Test `get_tags()` returns tag list on 200, empty list on 400/404, propagates error on 500/network failure
+- [x] 4.2 Test `get_tags_cached()`: cache hit skips API, cache miss calls API, expired cache refreshes, stale fallback on refresh failure
+- [x] 4.3 Test autocomplete callback returns filtered choices for valid source, empty list on API failure, defaults to leetcode when source unset

--- a/openspec/specs/slash-commands/spec.md
+++ b/openspec/specs/slash-commands/spec.md
@@ -241,3 +241,26 @@ The `/random` command SHALL reuse existing UI components for consistent display.
 - **WHEN** a user clicks any button on a random problem
 - **THEN** the interaction SHALL be routed through `InteractionHandlerCog` using the standard `problem|{source}|{id}|{action}` format
 
+### Requirement: Random problem tags autocomplete
+The `/random` command's `tags` parameter SHALL support dynamic autocomplete that fetches valid tags from the upstream API based on the currently selected source.
+
+#### Scenario: Tags autocomplete appears when typing
+- **WHEN** a user runs `/random`, selects a source, and begins typing in the `tags` field
+- **THEN** the bot SHALL display up to 25 tag suggestions filtered by the typed input, fetched from the API for the currently selected source
+
+#### Scenario: Tags autocomplete defaults to leetcode source
+- **WHEN** a user begins typing in the `tags` field without having explicitly selected a source
+- **THEN** the autocomplete SHALL use "leetcode" as the default source for tag suggestions
+
+#### Scenario: Tags autocomplete updates when source changes
+- **WHEN** a user changes the source value and then types in the `tags` field
+- **THEN** the autocomplete SHALL fetch and display tags for the newly selected source
+
+#### Scenario: Tags autocomplete empty result on API failure
+- **WHEN** the tags API is unavailable during autocomplete
+- **THEN** the bot SHALL return an empty autocomplete list without showing an error message, allowing the user to type tags manually
+
+#### Scenario: Tags autocomplete handles no matches
+- **WHEN** the user's typed input does not match any tag for the selected source
+- **THEN** the bot SHALL return an empty autocomplete list (no choices displayed)
+

--- a/openspec/specs/tag-autocomplete/spec.md
+++ b/openspec/specs/tag-autocomplete/spec.md
@@ -1,0 +1,81 @@
+# tag-autocomplete Specification
+
+## Purpose
+Tags autocomplete capability for the `/random` command, providing dynamic tag suggestions fetched from upstream API with TTL-based caching.
+
+## Requirements
+### Requirement: Tags by source API method
+The `OjApiClient` SHALL provide a `get_tags(source)` method that retrieves the valid tag list for a given problem source via `GET /api/v1/tags/{source}`.
+
+#### Scenario: Successful tag retrieval
+- **WHEN** `get_tags("leetcode")` is called
+- **THEN** the method SHALL send a `GET /api/v1/tags/leetcode` request and return the response as a list of strings
+
+#### Scenario: Empty tag list
+- **WHEN** the API returns an empty array for a valid source
+- **THEN** the method SHALL return an empty list
+
+#### Scenario: Invalid source
+- **WHEN** the API returns a 400 status for an invalid source
+- **THEN** the method SHALL return an empty list without raising an exception
+
+#### Scenario: API error
+- **WHEN** the API returns a 500 status or network error
+- **THEN** the method SHALL propagate standard error types (ApiNetworkError, ApiError)
+
+### Requirement: TTL-cached tags access
+The `OjApiClient` SHALL provide a `get_tags_cached(source)` method that caches tag results with a 24-hour TTL and supports stale fallback on API failure.
+
+#### Scenario: Cache hit
+- **WHEN** `get_tags_cached("leetcode")` is called and a cached result exists within the TTL (86400 seconds)
+- **THEN** the method SHALL return the cached tags without making an API request
+
+#### Scenario: Cache miss triggers API call
+- **WHEN** `get_tags_cached("leetcode")` is called and no cached result exists
+- **THEN** the method SHALL call `get_tags("leetcode")`, cache the result with a timestamp, and return the tags
+
+#### Scenario: Expired cache with successful refresh
+- **WHEN** `get_tags_cached("leetcode")` is called and the cache is older than TTL
+- **THEN** the method SHALL attempt a fresh API call, update the cache on success, and return the fresh tags
+
+#### Scenario: Expired cache with failed refresh returns stale
+- **WHEN** `get_tags_cached("leetcode")` is called, the cache is older than TTL, and the API call fails
+- **THEN** the method SHALL log a warning and return the stale cached tags
+
+#### Scenario: No cache and API failure returns empty
+- **WHEN** `get_tags_cached("spoj")` is called, no cache exists, and the API call fails
+- **THEN** the method SHALL return an empty list without raising an exception
+
+### Requirement: Tags autocomplete callback
+The `/random` command SHALL provide a dynamic autocomplete for the `tags` parameter that fetches valid tags for the currently selected source.
+
+#### Scenario: Autocomplete with selected source
+- **WHEN** a user has selected source "LeetCode" and starts typing in the `tags` field
+- **THEN** the autocomplete SHALL fetch tags for "leetcode" and return up to 25 matching `Choice` objects filtered by the typed input (case-insensitive substring match)
+
+#### Scenario: Autocomplete with default source
+- **WHEN** a user starts typing in the `tags` field without explicitly selecting a source
+- **THEN** the autocomplete SHALL default to source "leetcode" and return matching tags for that source
+
+#### Scenario: Autocomplete with no matching tags
+- **WHEN** the user's input does not match any tags for the selected source
+- **THEN** the autocomplete SHALL return an empty list of choices (no error message)
+
+#### Scenario: Autocomplete API failure graceful degradation
+- **WHEN** the tags API fails (network error, server error) during autocomplete
+- **THEN** the autocomplete SHALL return an empty list of choices without displaying an error to the user
+
+#### Scenario: Source change updates autocomplete suggestions
+- **WHEN** a user changes the source from "LeetCode" to "Codeforces" and then types in the `tags` field
+- **THEN** the autocomplete SHALL fetch and return tags for "codeforces"
+
+### Requirement: Startup tag preloading
+The bot SHALL optionally preload tags for popular sources on startup to eliminate cold-start latency for the first autocomplete request.
+
+#### Scenario: Preload on ready
+- **WHEN** the bot fires the `on_ready` event
+- **THEN** the bot SHALL initiate fire-and-forget `get_tags_cached()` calls for "leetcode" and "codeforces" without blocking command sync or schedule initialization
+
+#### Scenario: Preload failure does not block startup
+- **WHEN** a preload API call fails
+- **THEN** the failure SHALL be logged at warning level and SHALL NOT prevent the bot from starting or serving autocomplete requests

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import time
 from urllib.parse import quote
 
 import aiohttp
@@ -34,12 +35,15 @@ class ApiRateLimitError(Exception):
 
 
 class OjApiClient:
+    _TAGS_CACHE_TTL = 86400
+
     def __init__(self, base_url: str, token: str | None = None, timeout: int = 10):
         self._base_url = base_url.rstrip("/")
         self._token = token if token else None
         self._timeout = timeout
         self._session: aiohttp.ClientSession | None = None
         self._inflight: dict[str, asyncio.Future] = {}
+        self._tags_cache: dict[str, tuple[float, list[str]]] = {}
 
     async def start(self):
         if self._session and not self._session.closed:
@@ -201,3 +205,34 @@ class OjApiClient:
 
         items = self._list_items(response)
         return items[0] if items else None
+
+    async def get_tags(self, source: str) -> list[str]:
+        """Fetch valid tags for a problem source via GET /api/v1/tags/{source}."""
+        try:
+            response = await self._request("GET", f"tags/{quote(source)}")
+        except ApiError as e:
+            if e.status == 400:
+                return []
+            raise
+        if not response or not isinstance(response, list):
+            return []
+        return response
+
+    async def get_tags_cached(self, source: str) -> list[str]:
+        """Return cached tags within TTL; on cache miss or expiry, call API with stale fallback."""
+        now = time.time()
+        cached = self._tags_cache.get(source)
+        if cached is not None:
+            ts, tags = cached
+            if now - ts < self._TAGS_CACHE_TTL:
+                return tags
+        try:
+            tags = await self.get_tags(source)
+            self._tags_cache[source] = (now, tags)
+            return tags
+        except (ApiError, ApiNetworkError) as e:
+            if cached is not None:
+                logger.warning("Tags cache refresh failed for %s, using stale cache: %s", source, e)
+                return cached[1]
+            logger.warning("Tags cache miss and API failure for %s: %s", source, e)
+            return []

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -230,7 +230,7 @@ class OjApiClient:
             tags = await self.get_tags(source)
             self._tags_cache[source] = (now, tags)
             return tags
-        except (ApiError, ApiNetworkError) as e:
+        except Exception as e:
             if cached is not None:
                 logger.warning("Tags cache refresh failed for %s, using stale cache: %s", source, e)
                 return cached[1]

--- a/src/bot/app.py
+++ b/src/bot/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import pkgutil
 import re
@@ -115,6 +116,15 @@ def _register_runtime_handlers(bot: commands.Bot) -> None:
             bot.logger.warning("ScheduleManagerCog not found. Daily challenges will not be scheduled automatically.")
 
         bot.logger.info("Bot is ready and operational!")
+
+        async def _preload_tags():
+            for src in ["leetcode", "codeforces"]:
+                try:
+                    await bot.api.get_tags_cached(src)
+                except Exception as e:
+                    bot.logger.warning("Failed to preload tags for %s: %s", src, e)
+
+        asyncio.create_task(_preload_tags())
 
     @bot.event
     async def on_message(message):

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -205,6 +205,8 @@ class SlashCommandsCog(commands.Cog):
     @random_command.autocomplete("tags")
     async def random_tags_autocomplete(self, interaction: discord.Interaction, current: str):
         source = (interaction.namespace.source if interaction.namespace else None) or "leetcode"
+        if source == "all":
+            source = "leetcode"
         try:
             tags = await self.bot.api.get_tags_cached(source)
         except Exception:

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -202,6 +202,16 @@ class SlashCommandsCog(commands.Cog):
                 allowed_mentions=discord.AllowedMentions.none(),
             )
 
+    @random_command.autocomplete("tags")
+    async def random_tags_autocomplete(self, interaction: discord.Interaction, current: str):
+        source = (interaction.namespace.source if interaction.namespace else None) or "leetcode"
+        try:
+            tags = await self.bot.api.get_tags_cached(source)
+        except Exception:
+            tags = []
+        filtered = [t for t in tags if current.lower() in t.lower()]
+        return [app_commands.Choice(name=t, value=t) for t in filtered[:25]]
+
     # ── /problem ──────────────────────────────────────────────────────
 
     @app_commands.command(name="problem", description=app_commands.locale_str("problem.description"))

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
@@ -442,3 +442,231 @@ async def test_random_command_rating_same_min_max():
     bot.api.get_random_problem.assert_called_once_with(
         source="leetcode", difficulty=None, tags=None, rating_min=1500, rating_max=1500
     )
+
+
+# -- get_tags tests --
+
+
+@pytest.mark.asyncio
+async def test_get_tags_returns_list_on_200():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=["Array", "DP", "Graph"])
+
+    result = await api.get_tags("leetcode")
+
+    assert result == ["Array", "DP", "Graph"]
+    api._request.assert_awaited_once_with("GET", "tags/leetcode")
+
+
+@pytest.mark.asyncio
+async def test_get_tags_returns_empty_on_400():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=ApiError(400, "Bad Request"))
+
+    result = await api.get_tags("invalid")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_tags_returns_empty_on_404():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=None)
+
+    result = await api.get_tags("nonexistent")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_tags_propagates_api_error_500():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=ApiError(500, "Internal Server Error"))
+
+    with pytest.raises(ApiError):
+        await api.get_tags("leetcode")
+
+
+@pytest.mark.asyncio
+async def test_get_tags_propagates_network_error():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=ApiNetworkError("timeout"))
+
+    with pytest.raises(ApiNetworkError):
+        await api.get_tags("leetcode")
+
+
+# -- get_tags_cached tests --
+
+
+@pytest.mark.asyncio
+async def test_get_tags_cached_hit_skips_api():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock()
+    api._tags_cache["leetcode"] = (1000000.0, ["Array", "DP"])
+
+    with patch("time.time", return_value=1000100.0):
+        result = await api.get_tags_cached("leetcode")
+
+    assert result == ["Array", "DP"]
+    api._request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_tags_cached_miss_calls_api():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=["Graph", "Tree"])
+
+    with patch("time.time", return_value=2000000.0):
+        result = await api.get_tags_cached("leetcode")
+
+    assert result == ["Graph", "Tree"]
+    assert api._tags_cache["leetcode"] == (2000000.0, ["Graph", "Tree"])
+
+
+@pytest.mark.asyncio
+async def test_get_tags_cached_expired_refreshes():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._tags_cache["leetcode"] = (3000000.0, ["Old"])
+    api._request = AsyncMock(return_value=["New"])
+
+    with patch("time.time", return_value=3000000.0 + 86401):
+        result = await api.get_tags_cached("leetcode")
+
+    assert result == ["New"]
+    assert api._tags_cache["leetcode"] == (3000000.0 + 86401, ["New"])
+
+
+@pytest.mark.asyncio
+async def test_get_tags_cached_stale_fallback():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._tags_cache["leetcode"] = (4000000.0, ["Stale"])
+    api._request = AsyncMock(side_effect=ApiNetworkError("timeout"))
+
+    with patch("time.time", return_value=4000000.0 + 86401):
+        result = await api.get_tags_cached("leetcode")
+
+    assert result == ["Stale"]
+
+
+@pytest.mark.asyncio
+async def test_get_tags_cached_no_cache_api_failure_returns_empty():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=ApiNetworkError("timeout"))
+
+    result = await api.get_tags_cached("spoj")
+
+    assert result == []
+
+
+# -- tags autocomplete tests --
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_returns_filtered_choices():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(return_value=["Array", "DP", "Graph", "Tree", "Sort"])
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = "leetcode"
+
+    result = await cog.random_tags_autocomplete(interaction, "ar")
+
+    assert len(result) == 1
+    assert result[0].name == "Array"
+    assert result[0].value == "Array"
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_defaults_to_leetcode():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(return_value=["Array", "DP"])
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = None
+
+    await cog.random_tags_autocomplete(interaction, "a")
+
+    bot.api.get_tags_cached.assert_awaited_once_with("leetcode")
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_no_namespace_defaults_to_leetcode():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(return_value=["Array"])
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = None
+
+    await cog.random_tags_autocomplete(interaction, "a")
+
+    bot.api.get_tags_cached.assert_awaited_once_with("leetcode")
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_api_failure_returns_empty():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(side_effect=ApiNetworkError("timeout"))
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = "leetcode"
+
+    result = await cog.random_tags_autocomplete(interaction, "a")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_no_matches_returns_empty():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(return_value=["Array", "DP"])
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = "leetcode"
+
+    result = await cog.random_tags_autocomplete(interaction, "xyz")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_respects_source_change():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(return_value=["Brute Force", "Greedy"])
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = "codeforces"
+
+    await cog.random_tags_autocomplete(interaction, "g")
+
+    bot.api.get_tags_cached.assert_awaited_once_with("codeforces")
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_limits_to_25():
+    bot = _make_bot()
+    tags = [f"Tag{i}" for i in range(50)]
+    bot.api.get_tags_cached = AsyncMock(return_value=tags)
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = "leetcode"
+
+    result = await cog.random_tags_autocomplete(interaction, "Tag")
+
+    assert len(result) == 25

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -559,6 +559,32 @@ async def test_get_tags_cached_stale_fallback():
 
 
 @pytest.mark.asyncio
+async def test_get_tags_cached_stale_fallback_on_processing_error():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._tags_cache["leetcode"] = (5000000.0, ["Stale"])
+    api._request = AsyncMock(side_effect=ApiProcessingError())
+
+    with patch("time.time", return_value=5000000.0 + 86401):
+        result = await api.get_tags_cached("leetcode")
+
+    assert result == ["Stale"]
+
+
+@pytest.mark.asyncio
+async def test_get_tags_cached_stale_fallback_on_rate_limit():
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._tags_cache["leetcode"] = (6000000.0, ["Stale"])
+    api._request = AsyncMock(side_effect=ApiRateLimitError(5.0))
+
+    with patch("time.time", return_value=6000000.0 + 86401):
+        result = await api.get_tags_cached("leetcode")
+
+    assert result == ["Stale"]
+
+
+@pytest.mark.asyncio
 async def test_get_tags_cached_no_cache_api_failure_returns_empty():
     api = OjApiClient("http://test")
     api._session = AsyncMock()
@@ -655,6 +681,20 @@ async def test_tags_autocomplete_respects_source_change():
     await cog.random_tags_autocomplete(interaction, "g")
 
     bot.api.get_tags_cached.assert_awaited_once_with("codeforces")
+
+
+@pytest.mark.asyncio
+async def test_tags_autocomplete_source_all_defaults_to_leetcode():
+    bot = _make_bot()
+    bot.api.get_tags_cached = AsyncMock(return_value=["Array"])
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    interaction.namespace = MagicMock()
+    interaction.namespace.source = "all"
+
+    await cog.random_tags_autocomplete(interaction, "a")
+
+    bot.api.get_tags_cached.assert_awaited_once_with("leetcode")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `get_tags(source)` and `get_tags_cached(source)` to `OjApiClient` with 24h TTL cache and stale-while-revalidate fallback
- Add `@random_command.autocomplete("tags")` callback that fetches valid tags for the currently selected source from `interaction.namespace`
- Fire-and-forget preload leetcode/codeforces tags in `on_ready`
- Add 17 tests covering API methods, cache behavior, and autocomplete callback
- Archive `random-tags-autocomplete` OpenSpec change with all artifacts

## Changes

- `src/bot/api_client.py` — `get_tags(source)` calls `GET /api/v1/tags/{source}`; `get_tags_cached(source)` with TTL cache and stale fallback on API failure
- `src/bot/cogs/slash_commands_cog.py` — autocomplete callback reads source from namespace, filters by current input, returns up to 25 `Choice` objects
- `src/bot/app.py` — fire-and-forget preload via `asyncio.create_task` in `on_ready`; failures logged at warning level
- `tests/test_random_command.py` — 17 new tests for `get_tags`, `get_tags_cached`, and autocomplete callback
- `openspec/` — sync delta specs to main, archive completed change

## Test plan

- [x] `uv run --extra dev pytest tests/test_random_command.py` — 44 passed
- [x] `uv run --extra dev pytest` — 154 passed, 0 failed

## Notes

- Tags cache uses 24h TTL with stale-while-revalidate: expired cache returns stale data if API refresh fails
- Default source is "leetcode" when user has not explicitly selected a source
- Autocomplete graceful degradation: API failure returns empty list without error to user