### PR TITLE
🐛 fix(daily): deduplicate daily challenge requests

### DIFF
--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/design.md
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The bot currently sends daily challenges through two paths: manual slash commands and APScheduler jobs. Manual `/daily` calls delegate to shared UI helpers, while scheduled delivery creates one memory-backed job per configured server. The API client already coalesces identical in-flight HTTP requests, and interaction handling already uses an `asyncio.Lock` plus in-flight key set for duplicate LLM button requests.
+
+The remaining gap is above the HTTP layer: concurrent scheduled jobs can still perform duplicate render/delivery work, scheduler defaults currently allow overlapping instances for the same server, and short bursts of daily requests after an in-flight request completes can re-fetch the same daily payload and history.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent overlapping scheduled daily execution for the same server.
+- Prevent concurrent duplicate scheduled delivery for the same server/channel/domain/date within one bot process.
+- Reuse daily challenge payload data for short bursts of manual or scheduled daily requests.
+- Preserve localized embed generation per request or guild.
+- Keep the implementation in-memory and dependency-free for the current single-process bot runtime.
+
+**Non-Goals:**
+- Add Redis or another distributed locking service.
+- Guarantee cross-process or cross-shard delivery idempotency.
+- Persist daily delivery history in the database.
+- Suppress legitimate manual `/daily` responses after previous requests have completed.
+- Cache Discord embeds or views across locales.
+
+## Decisions
+
+### Use conservative APScheduler defaults for daily jobs
+
+Set scheduled daily job defaults to `coalesce=True` and `max_instances=1` while retaining the existing misfire grace behavior. Daily challenge delivery is a once-per-day server task, so overlapping instances add risk without meaningful throughput benefit.
+
+Alternative considered: keep `max_instances=3` and rely only on application-level guards. This would still allow unnecessary duplicate job execution and makes the scheduler less aligned with daily-delivery semantics.
+
+### Add an in-memory scheduled delivery guard
+
+Use an `asyncio.Lock` plus an in-flight key set for scheduled sends. The key should include at least server id, channel id, domain, and daily date. The guard should live in the scheduled delivery path rather than blocking all manual `/daily` usage.
+
+Alternative considered: database idempotency table. This is stronger across restarts/processes, but the current runtime uses one bot process and the immediate issue is concurrent overlap, so an in-memory guard is simpler and lower risk.
+
+### Cache daily payload data, not Discord UI objects
+
+Introduce a short-lived daily payload cache for the fetched challenge and same-day historical problems. Embed/view construction remains per request so locale, role mention, ephemeral/public response, and interaction context remain correct.
+
+Alternative considered: cache only `OjApiClient.get_daily()`. That helps the current challenge but still repeats history fan-out. Caching the payload directly matches the rendering workflow while still keeping the cache small.
+
+### Reuse existing concurrency idioms
+
+Follow existing project patterns: `asyncio.Lock` plus in-flight set from interaction handling, short TTL cache from API tags/recent submissions, and bounded fan-out with semaphores for history fetches. Avoid introducing a new service framework unless implementation needs a tiny helper module for clarity.
+
+Alternative considered: broad refactor into a daily service layer. This may be useful later, but the current scope can remain small by placing helpers near current daily rendering code.
+
+## Risks / Trade-offs
+
+- In-memory guards do not survive bot restarts or coordinate across multiple processes → acceptable for current single-process runtime; document DB idempotency as a future option if deployment topology changes.
+- A guard key chosen too broadly could suppress valid sends → use scheduled-only keys for delivery suppression and keep manual `/daily` responses valid.
+- A guard key chosen too narrowly may miss duplicates → include server, channel, domain, and date for scheduled delivery.
+- Daily payload TTL may serve stale data around day boundaries → derive cache keys from the challenge date or explicit date and keep TTL short.
+- Caching payloads but rebuilding embeds still costs CPU → acceptable because the expensive duplicate work is upstream daily/history retrieval, and per-locale embed generation is required.

--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/proposal.md
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Concurrent `/daily` invocations and clustered scheduled daily jobs can duplicate upstream daily challenge work and, in scheduled flows, risk overlapping delivery for the same server. This is especially visible when many servers fire daily jobs at the same configured minute or when users repeatedly request the same daily challenge.
+
+## What Changes
+
+- Tighten scheduled daily job execution so a server's daily job does not overlap with a previous run.
+- Add duplicate prevention for scheduled daily delivery keyed by server/channel/domain/date so one server does not send the same scheduled daily challenge concurrently.
+- Add short-lived daily challenge payload reuse so repeated daily challenge rendering can share fetched challenge and history data without changing localized embed generation.
+- Preserve manual `/daily` behavior: users can still request current or date-specific daily challenges, with any duplicate suppression limited to concurrent in-flight work and not a persistent block.
+- No breaking changes.
+
+## Capabilities
+
+### New Capabilities
+- `daily-request-deduplication`: Prevent duplicate in-flight daily challenge work and scheduled delivery while preserving expected manual command behavior.
+
+### Modified Capabilities
+- `daily-schedule`: Scheduled daily jobs must avoid overlapping per-server execution and duplicate same-day scheduled delivery.
+- `slash-commands`: Daily slash commands should reuse in-flight or cached daily data where possible without suppressing valid user responses.
+
+## Impact
+
+- Affected code: `src/bot/cogs/schedule_manager_cog.py`, `src/bot/cogs/slash_commands_cog.py`, `src/bot/utils/ui_helpers.py`, and possibly `src/bot/api_client.py` or a small daily-service helper.
+- Affected behavior: scheduled daily challenge execution, concurrent `/daily` handling, daily challenge/history fetch reuse.
+- Dependencies: no new external runtime dependency is expected; implementation should use existing `asyncio`, APScheduler, and in-memory cache patterns.
+- Testing: add or update async unit tests for scheduler defaults, duplicate scheduled delivery guard, and daily payload reuse.

--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/specs/daily-request-deduplication/spec.md
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/specs/daily-request-deduplication/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: In-flight daily payload reuse
+The system SHALL reuse in-flight or short-lived cached daily challenge payload data for identical domain/date requests within one bot process.
+
+#### Scenario: Concurrent current daily payload requests
+- **WHEN** multiple daily challenge flows request the current daily payload for the same domain while the first request is still processing
+- **THEN** the system SHALL await the same in-flight payload work instead of starting duplicate upstream daily and history fetches
+
+#### Scenario: Short burst after payload completion
+- **WHEN** a daily challenge flow requests the same domain/date shortly after a successful payload fetch
+- **THEN** the system SHALL reuse the cached payload without calling the upstream daily and history APIs again
+
+#### Scenario: Locale-specific rendering remains independent
+- **WHEN** two guilds render the same cached daily payload using different resolved locales
+- **THEN** the system SHALL build separate localized Discord embeds and views from the shared payload
+
+### Requirement: Scheduled daily duplicate delivery guard
+The system SHALL prevent concurrent duplicate scheduled daily delivery for the same server, channel, domain, and daily date within one bot process.
+
+#### Scenario: Duplicate scheduled delivery already in progress
+- **WHEN** a scheduled daily job starts while another scheduled delivery with the same server, channel, domain, and daily date is still running
+- **THEN** the system SHALL skip the duplicate delivery attempt and log that the scheduled delivery is already in progress
+
+#### Scenario: Guard cleanup after completion
+- **WHEN** a scheduled daily delivery succeeds, fails, or is skipped due to an API error
+- **THEN** the system SHALL remove its in-flight delivery key so later legitimate scheduled attempts are not permanently blocked
+
+#### Scenario: Manual daily requests are not persistently suppressed
+- **WHEN** a user runs `/daily` after a previous `/daily` request has completed
+- **THEN** the bot SHALL still send a valid response while reusing cached payload data when available

--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/specs/daily-schedule/spec.md
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/specs/daily-schedule/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Daily challenge delivery
+The system SHALL fetch and post the daily challenge to the configured channel at the scheduled time using localized UI text, while preventing concurrent duplicate delivery for the same server, channel, domain, and daily date within one bot process.
+
+#### Scenario: Successful localized delivery
+- **WHEN** a scheduled job fires for a server with `language = "en-US"`
+- **THEN** the system SHALL fetch the current daily challenge and post embed text, field names, button labels, and footer text in English
+
+#### Scenario: Delivery without language setting
+- **WHEN** a scheduled job fires for a server without a language setting
+- **THEN** the system SHALL resolve locale from configured default and hard fallback rules before posting
+
+#### Scenario: Concurrent duplicate scheduled delivery
+- **WHEN** two scheduled delivery attempts for the same server, channel, domain, and daily date overlap
+- **THEN** only one attempt SHALL send a Discord message and the duplicate attempt SHALL be skipped
+
+### Requirement: Job configuration defaults
+APScheduler jobs SHALL use specific defaults for reliability and SHALL NOT run overlapping instances of the same server's daily challenge job.
+
+#### Scenario: Misfire grace time
+- **WHEN** a job misses its scheduled time (e.g., bot was offline)
+- **THEN** the job SHALL still execute if within the 5-minute misfire grace period
+
+#### Scenario: Max instances
+- **WHEN** a job is triggered while a previous instance for the same server is still running
+- **THEN** the scheduler SHALL prevent a concurrent second instance for that server's daily job
+
+#### Scenario: Coalesced missed runs
+- **WHEN** multiple missed executions for the same daily job are eligible to run after scheduler recovery
+- **THEN** the scheduler SHALL coalesce them into a single execution

--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/specs/slash-commands/spec.md
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/specs/slash-commands/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Daily challenge command
+The `/daily` command SHALL fetch and display the current daily challenge from LeetCode with user-facing text localized to the resolved locale, reusing in-flight or cached daily payload data where available without suppressing valid user responses.
+
+#### Scenario: Fetch today's challenge
+- **WHEN** a user runs `/daily`
+- **THEN** the bot SHALL display the daily challenge embed with localized UI text, problem info, difficulty, tags, and interactive buttons
+
+#### Scenario: Fetch challenge by date
+- **WHEN** a user runs `/daily` with a date parameter in YYYY-MM-DD format
+- **THEN** the bot SHALL display the daily challenge for that date with localized UI text
+
+#### Scenario: CN domain support
+- **WHEN** a user runs `/daily_cn`
+- **THEN** the bot SHALL fetch the daily challenge from leetcode.cn instead of leetcode.com
+
+#### Scenario: Public toggle
+- **WHEN** a user runs `/daily` with the `public` parameter set to True
+- **THEN** the response SHALL be visible to all users in the channel instead of ephemeral
+
+#### Scenario: Concurrent identical daily data requests
+- **WHEN** multiple users run `/daily` for the same domain/date while daily payload data is already in flight
+- **THEN** the bot SHALL reuse the in-flight daily payload data and still send each valid interaction its own response
+
+#### Scenario: Cached daily data reuse
+- **WHEN** a user runs `/daily` for a domain/date whose daily payload is still within the short-lived cache window
+- **THEN** the bot SHALL render the response from cached payload data without refetching the same daily challenge and history data

--- a/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/tasks.md
+++ b/openspec/changes/archive/2026-06-03-prevent-duplicate-daily-requests/tasks.md
@@ -1,0 +1,30 @@
+## 1. Scheduler overlap control
+
+- [x] 1.1 Update scheduled daily job defaults to prevent overlapping instances and coalesce missed runs.
+- [x] 1.2 Add tests or assertions covering `coalesce=True`, `max_instances=1`, and existing misfire grace behavior.
+
+## 2. Daily payload reuse
+
+- [x] 2.1 Add a small in-memory daily payload cache keyed by domain and resolved date.
+- [x] 2.2 Add in-flight payload coalescing so concurrent identical daily payload requests share the same work.
+- [x] 2.3 Refactor current and date-specific daily rendering paths to use the shared payload helper while still building localized embeds per request.
+- [x] 2.4 Add async tests proving concurrent identical payload requests do not duplicate daily/history API fetches.
+
+## 3. Scheduled delivery duplicate guard
+
+- [x] 3.1 Add an in-memory scheduled delivery guard keyed by server id, channel id, domain, and daily date.
+- [x] 3.2 Ensure duplicate scheduled delivery attempts are skipped with a log message while the original delivery is in progress.
+- [x] 3.3 Ensure delivery guard keys are cleaned up after success, failure, processing skip, or rate-limit skip.
+- [x] 3.4 Add tests covering duplicate scheduled delivery skip and cleanup after exceptions.
+
+## 4. Manual daily behavior preservation
+
+- [x] 4.1 Verify manual `/daily` and `/daily_cn` still return a response for each valid interaction.
+- [x] 4.2 Verify date-specific `/daily date:YYYY-MM-DD` still works and uses the shared payload path where applicable.
+- [x] 4.3 Verify public and ephemeral response behavior remains unchanged.
+
+## 5. Validation
+
+- [x] 5.1 Run the focused test suite for daily commands, scheduler behavior, and shared UI helpers.
+- [x] 5.2 Run `uv run --extra dev pytest` for the full test suite.
+- [x] 5.3 Run `uv run ruff check .` to confirm lint quality.

--- a/openspec/specs/daily-request-deduplication/spec.md
+++ b/openspec/specs/daily-request-deduplication/spec.md
@@ -1,0 +1,35 @@
+# daily-request-deduplication Specification
+
+## Purpose
+Define process-local safeguards that prevent duplicate daily challenge upstream work and duplicate scheduled daily deliveries while preserving valid user responses.
+
+## Requirements
+### Requirement: In-flight daily payload reuse
+The system SHALL reuse in-flight or short-lived cached daily challenge payload data for identical domain/date requests within one bot process.
+
+#### Scenario: Concurrent current daily payload requests
+- **WHEN** multiple daily challenge flows request the current daily payload for the same domain while the first request is still processing
+- **THEN** the system SHALL await the same in-flight payload work instead of starting duplicate upstream daily and history fetches
+
+#### Scenario: Short burst after payload completion
+- **WHEN** a daily challenge flow requests the same domain/date shortly after a successful payload fetch
+- **THEN** the system SHALL reuse the cached payload without calling the upstream daily and history APIs again
+
+#### Scenario: Locale-specific rendering remains independent
+- **WHEN** two guilds render the same cached daily payload using different resolved locales
+- **THEN** the system SHALL build separate localized Discord embeds and views from the shared payload
+
+### Requirement: Scheduled daily duplicate delivery guard
+The system SHALL prevent concurrent duplicate scheduled daily delivery for the same server, channel, domain, and daily date within one bot process.
+
+#### Scenario: Duplicate scheduled delivery already in progress
+- **WHEN** a scheduled daily job starts while another scheduled delivery with the same server, channel, domain, and daily date is still running
+- **THEN** the system SHALL skip the duplicate delivery attempt and log that the scheduled delivery is already in progress
+
+#### Scenario: Guard cleanup after completion
+- **WHEN** a scheduled daily delivery succeeds, fails, or is skipped due to an API error
+- **THEN** the system SHALL remove its in-flight delivery key so later legitimate scheduled attempts are not permanently blocked
+
+#### Scenario: Manual daily requests are not persistently suppressed
+- **WHEN** a user runs `/daily` after a previous `/daily` request has completed
+- **THEN** the bot SHALL still send a valid response while reusing cached payload data when available

--- a/openspec/specs/daily-schedule/spec.md
+++ b/openspec/specs/daily-schedule/spec.md
@@ -38,7 +38,7 @@ The system SHALL support adding, rescheduling, and removing server schedules at 
 - **THEN** the error SHALL be logged but SHALL NOT crash the bot
 
 ### Requirement: Daily challenge delivery
-The system SHALL fetch and post the daily challenge to the configured channel at the scheduled time using localized UI text.
+The system SHALL fetch and post the daily challenge to the configured channel at the scheduled time using localized UI text, while preventing concurrent duplicate delivery for the same server, channel, domain, and daily date within one bot process.
 
 #### Scenario: Successful localized delivery
 - **WHEN** a scheduled job fires for a server with `language = "en-US"`
@@ -48,16 +48,24 @@ The system SHALL fetch and post the daily challenge to the configured channel at
 - **WHEN** a scheduled job fires for a server without a language setting
 - **THEN** the system SHALL resolve locale from configured default and hard fallback rules before posting
 
+#### Scenario: Concurrent duplicate scheduled delivery
+- **WHEN** two scheduled delivery attempts for the same server, channel, domain, and daily date overlap
+- **THEN** only one attempt SHALL send a Discord message and the duplicate attempt SHALL be skipped
+
 ### Requirement: Job configuration defaults
-APScheduler jobs SHALL use specific defaults for reliability.
+APScheduler jobs SHALL use specific defaults for reliability and SHALL NOT run overlapping instances of the same server's daily challenge job.
 
 #### Scenario: Misfire grace time
 - **WHEN** a job misses its scheduled time (e.g., bot was offline)
 - **THEN** the job SHALL still execute if within the 5-minute misfire grace period
 
 #### Scenario: Max instances
-- **WHEN** a job is triggered while a previous instance is still running
-- **THEN** the scheduler SHALL allow up to 3 concurrent instances
+- **WHEN** a daily job is triggered while a previous instance for the same server is still running
+- **THEN** the scheduler SHALL use `max_instances=1` to prevent a concurrent second instance for that server's daily job
+
+#### Scenario: Coalesced missed runs
+- **WHEN** multiple missed executions for the same daily job are eligible to run after scheduler recovery
+- **THEN** the scheduler SHALL coalesce them into a single execution
 
 ### Requirement: Job persistence across restarts
 APScheduler jobs use MemoryJobStore and SHALL be recreated from database settings on each bot restart.

--- a/openspec/specs/slash-commands/spec.md
+++ b/openspec/specs/slash-commands/spec.md
@@ -4,7 +4,7 @@
 TBD - created by archiving change init-project-specs. Update Purpose after archive.
 ## Requirements
 ### Requirement: Daily challenge command
-The `/daily` command SHALL fetch and display the current daily challenge from LeetCode with user-facing text localized to the resolved locale.
+The `/daily` command SHALL fetch and display the current daily challenge from LeetCode with user-facing text localized to the resolved locale, reusing in-flight or cached daily payload data where available without suppressing valid user responses.
 
 #### Scenario: Fetch today's challenge
 - **WHEN** a user runs `/daily`
@@ -21,6 +21,14 @@ The `/daily` command SHALL fetch and display the current daily challenge from Le
 #### Scenario: Public toggle
 - **WHEN** a user runs `/daily` with the `public` parameter set to True
 - **THEN** the response SHALL be visible to all users in the channel instead of ephemeral
+
+#### Scenario: Concurrent identical daily data requests
+- **WHEN** multiple users run `/daily` for the same domain/date while daily payload data is already in flight
+- **THEN** the bot SHALL reuse the in-flight daily payload data and still send each valid interaction its own response
+
+#### Scenario: Cached daily data reuse
+- **WHEN** a user runs `/daily` for a domain/date whose daily payload is still within the short-lived cache window
+- **THEN** the bot SHALL render the response from cached payload data without refetching the same daily challenge and history data
 
 ### Requirement: Problem lookup command
 The `/problem` command SHALL fetch and display specific problems by ID, URL, or slug with user-facing text localized to the resolved locale.

--- a/src/bot/cogs/schedule_manager_cog.py
+++ b/src/bot/cogs/schedule_manager_cog.py
@@ -98,7 +98,7 @@ class ScheduleManagerCog(commands.Cog):
                 func=self.send_daily_challenge_job,
                 trigger=trigger,
                 id=job_id,
-                args=[server_id, channel_id, role_id],
+                args=[server_id, channel_id, role_id, timezone_str],
                 replace_existing=True,
                 misfire_grace_time=300,  # 5 minutes grace time
                 name=f"Daily Challenge for Server {server_id}",
@@ -124,7 +124,13 @@ class ScheduleManagerCog(commands.Cog):
         async with self.scheduled_delivery_lock:
             self.scheduled_deliveries_in_progress.discard(delivery_key)
 
-    async def send_daily_challenge_job(self, server_id: int, channel_id: int, role_id: int = None):
+    async def send_daily_challenge_job(
+        self,
+        server_id: int,
+        channel_id: int,
+        role_id: int = None,
+        timezone_str: str = DEFAULT_TIMEZONE,
+    ):
         """Job function called by APScheduler to send daily challenges"""
         self.logger.info(f"APScheduler triggered: Sending daily challenge for server {server_id}")
 
@@ -136,7 +142,8 @@ class ScheduleManagerCog(commands.Cog):
 
         delays = [2, 4, 8]
 
-        daily_date = datetime.now(pytz.UTC).strftime("%Y-%m-%d")
+        scheduled_timezone = parse_timezone(timezone_str)
+        daily_date = datetime.now(scheduled_timezone).strftime("%Y-%m-%d")
         delivery_key = (server_id, channel_id, "com", daily_date)
         if not await self._mark_scheduled_delivery_started(delivery_key):
             self.logger.info(

--- a/src/bot/cogs/schedule_manager_cog.py
+++ b/src/bot/cogs/schedule_manager_cog.py
@@ -157,6 +157,7 @@ class ScheduleManagerCog(commands.Cog):
                         channel_id=channel_id,
                         role_id=role_id,
                         guild_locale=guild_locale,
+                        date_str=daily_date,
                     )
                     if result:
                         self.logger.info(f"Sent daily challenge for server {server_id}: {result.get('title')}")

--- a/src/bot/cogs/schedule_manager_cog.py
+++ b/src/bot/cogs/schedule_manager_cog.py
@@ -1,6 +1,7 @@
 # cogs/schedule_manager_cog.py
 import asyncio
 import random
+from datetime import datetime
 
 import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -17,11 +18,13 @@ class ScheduleManagerCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.logger = get_scheduler_logger()
+        self.scheduled_delivery_lock = asyncio.Lock()
+        self.scheduled_deliveries_in_progress = set()
 
         # Setup APScheduler (uses MemoryJobStore by default, avoiding Discord object serialization issues)
         job_defaults = {
-            "coalesce": False,
-            "max_instances": 3,
+            "coalesce": True,
+            "max_instances": 1,
             "misfire_grace_time": 300,  # 5 minutes grace time
         }
 
@@ -110,6 +113,17 @@ class ScheduleManagerCog(commands.Cog):
         except Exception as e:
             self.logger.error(f"Server {server_id}: Error adding schedule: {e}", exc_info=True)
 
+    async def _mark_scheduled_delivery_started(self, delivery_key: tuple[int, int, str, str]) -> bool:
+        async with self.scheduled_delivery_lock:
+            if delivery_key in self.scheduled_deliveries_in_progress:
+                return False
+            self.scheduled_deliveries_in_progress.add(delivery_key)
+            return True
+
+    async def _cleanup_scheduled_delivery(self, delivery_key: tuple[int, int, str, str]) -> None:
+        async with self.scheduled_delivery_lock:
+            self.scheduled_deliveries_in_progress.discard(delivery_key)
+
     async def send_daily_challenge_job(self, server_id: int, channel_id: int, role_id: int = None):
         """Job function called by APScheduler to send daily challenges"""
         self.logger.info(f"APScheduler triggered: Sending daily challenge for server {server_id}")
@@ -122,33 +136,52 @@ class ScheduleManagerCog(commands.Cog):
 
         delays = [2, 4, 8]
 
-        for attempt in range(len(delays) + 1):
-            try:
-                result = await send_daily_challenge(
-                    bot=self.bot, channel_id=channel_id, role_id=role_id, guild_locale=guild_locale
-                )
-                if result:
-                    self.logger.info(f"Sent daily challenge for server {server_id}: {result.get('title')}")
-                else:
-                    self.logger.warning(f"Failed to send daily challenge for server {server_id}")
-                return
-            except ApiProcessingError:
-                if attempt < len(delays):
-                    delay = delays[attempt] + random.uniform(-0.5, 0.5)
-                    self.logger.warning(
-                        f"Server {server_id}: API processing (attempt {attempt + 1}/{len(delays) + 1}), "
-                        f"retry in {delay:.1f}s"
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-            except ApiRateLimitError:
-                self.logger.warning(f"Server {server_id}: rate limited, skipping daily challenge")
-                return
-            except Exception as e:
-                self.logger.error(f"Error in send_daily_challenge_job for server {server_id}: {e}", exc_info=True)
-                return
+        daily_date = datetime.now(pytz.UTC).strftime("%Y-%m-%d")
+        delivery_key = (server_id, channel_id, "com", daily_date)
+        if not await self._mark_scheduled_delivery_started(delivery_key):
+            self.logger.info(
+                "Scheduled daily delivery already in progress for server %s, channel %s, domain %s, "
+                "date %s; skipping duplicate",
+                server_id,
+                channel_id,
+                "com",
+                daily_date,
+            )
+            return
 
-        self.logger.warning(f"Server {server_id}: API still processing after {len(delays) + 1} attempts, skipping")
+        try:
+            for attempt in range(len(delays) + 1):
+                try:
+                    result = await send_daily_challenge(
+                        bot=self.bot,
+                        channel_id=channel_id,
+                        role_id=role_id,
+                        guild_locale=guild_locale,
+                    )
+                    if result:
+                        self.logger.info(f"Sent daily challenge for server {server_id}: {result.get('title')}")
+                    else:
+                        self.logger.warning(f"Failed to send daily challenge for server {server_id}")
+                    return
+                except ApiProcessingError:
+                    if attempt < len(delays):
+                        delay = delays[attempt] + random.uniform(-0.5, 0.5)
+                        self.logger.warning(
+                            f"Server {server_id}: API processing (attempt {attempt + 1}/{len(delays) + 1}), "
+                            f"retry in {delay:.1f}s"
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                except ApiRateLimitError:
+                    self.logger.warning(f"Server {server_id}: rate limited, skipping daily challenge")
+                    return
+                except Exception as e:
+                    self.logger.error(f"Error in send_daily_challenge_job for server {server_id}: {e}", exc_info=True)
+                    return
+
+            self.logger.warning(f"Server {server_id}: API still processing after {len(delays) + 1} attempts, skipping")
+        finally:
+            await self._cleanup_scheduled_delivery(delivery_key)
 
     async def reschedule_daily_challenge(self, server_id: int = None):
         """Reschedule the daily challenge for a specific server or all servers"""

--- a/src/bot/cogs/schedule_manager_cog.py
+++ b/src/bot/cogs/schedule_manager_cog.py
@@ -164,7 +164,6 @@ class ScheduleManagerCog(commands.Cog):
                         channel_id=channel_id,
                         role_id=role_id,
                         guild_locale=guild_locale,
-                        date_str=daily_date,
                     )
                     if result:
                         self.logger.info(f"Sent daily challenge for server {server_id}: {result.get('title')}")

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -10,7 +10,6 @@ from bot.api_client import ApiError, ApiNetworkError, ApiProcessingError, ApiRat
 from bot.utils.config import DEFAULT_POST_TIME, DEFAULT_TIMEZONE, parse_timezone
 from bot.utils.logger import get_commands_logger
 from bot.utils.ui_helpers import (
-    _fetch_daily_history,
     _get_locale,
     create_problem_embed,
     create_problem_view,
@@ -19,6 +18,7 @@ from bot.utils.ui_helpers import (
     create_settings_embed,
     create_submission_embed,
     create_submission_view,
+    get_daily_payload,
     get_source_label,
     get_source_logo_url,
     send_api_error,
@@ -68,21 +68,21 @@ class SlashCommandsCog(commands.Cog):
             await interaction.followup.send(i18n.t("errors.validation.date_format", locale), ephemeral=not public)
             return
         try:
-            challenge_info = await self.bot.api.get_daily(domain, date)
-            if not challenge_info:
+            payload = await get_daily_payload(self.bot, domain, date)
+            if not payload:
                 await interaction.followup.send(
                     i18n.t("errors.validation.not_found_for_date", locale, date=date), ephemeral=not public
                 )
                 return
 
-            history_problems = await _fetch_daily_history(self.bot, domain, date)
+            challenge_info = payload["challenge_info"]
             embed = await create_problem_embed(
                 problem_info=challenge_info,
                 bot=self.bot,
                 domain=domain,
                 is_daily=True,
                 date_str=date,
-                history_problems=history_problems,
+                history_problems=payload["history_problems"],
                 locale=locale,
             )
             view = await create_problem_view(problem_info=challenge_info, bot=self.bot, domain=domain, locale=locale)

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -927,9 +927,40 @@ def create_inspiration_embed(
 
 
 _DAILY_PAYLOAD_CACHE_TTL_SECONDS = 60
-_DAILY_PAYLOAD_CACHE: dict[tuple[str, str], tuple[float, dict[str, Any]]] = {}
-_DAILY_PAYLOAD_IN_FLIGHT: dict[tuple[str, str], asyncio.Task] = {}
-_DAILY_PAYLOAD_LOCK = asyncio.Lock()
+
+
+def _get_daily_payload_state(
+    bot: Any,
+) -> tuple[dict[tuple[str, str], tuple[float, dict[str, Any]]], dict[tuple[str, str], asyncio.Task], asyncio.Lock]:
+    cache = getattr(bot, "_daily_payload_cache", None)
+    if cache is None:
+        cache = {}
+        setattr(bot, "_daily_payload_cache", cache)
+
+    in_flight = getattr(bot, "_daily_payload_in_flight", None)
+    if in_flight is None:
+        in_flight = {}
+        setattr(bot, "_daily_payload_in_flight", in_flight)
+
+    lock = getattr(bot, "_daily_payload_lock", None)
+    running_loop = asyncio.get_running_loop()
+    if lock is None or getattr(bot, "_daily_payload_lock_loop", None) is not running_loop:
+        lock = asyncio.Lock()
+        setattr(bot, "_daily_payload_lock", lock)
+        setattr(bot, "_daily_payload_lock_loop", running_loop)
+
+    return cache, in_flight, lock
+
+
+def _prune_expired_daily_payloads(
+    cache: dict[tuple[str, str], tuple[float, dict[str, Any]]],
+    now: float,
+) -> None:
+    expired_keys = [
+        key for key, (created_at, _) in cache.items() if now - created_at >= _DAILY_PAYLOAD_CACHE_TTL_SECONDS
+    ]
+    for key in expired_keys:
+        cache.pop(key, None)
 
 
 async def _fetch_daily_history(bot: Any, domain: str, anchor_date: str) -> List[Dict[str, Any]]:
@@ -979,31 +1010,36 @@ async def _fetch_daily_payload(
 async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None = None) -> dict[str, Any] | None:
     resolved_date = date_str or datetime.now(pytz.UTC).strftime("%Y-%m-%d")
     cache_key = (domain, resolved_date)
-    now = time.monotonic()
+    cache, in_flight, lock = _get_daily_payload_state(bot)
 
-    async with _DAILY_PAYLOAD_LOCK:
-        cached = _DAILY_PAYLOAD_CACHE.get(cache_key)
-        if cached and now - cached[0] < _DAILY_PAYLOAD_CACHE_TTL_SECONDS:
+    async with lock:
+        now = time.monotonic()
+        _prune_expired_daily_payloads(cache, now)
+
+        cached = cache.get(cache_key)
+        if cached:
             return cached[1]
 
-        task = _DAILY_PAYLOAD_IN_FLIGHT.get(cache_key)
+        task = in_flight.get(cache_key)
         if task is None:
             task = asyncio.create_task(_fetch_daily_payload(bot, domain, date_str, resolved_date))
-            _DAILY_PAYLOAD_IN_FLIGHT[cache_key] = task
+            in_flight[cache_key] = task
 
     try:
         payload = await task
     finally:
-        async with _DAILY_PAYLOAD_LOCK:
-            if _DAILY_PAYLOAD_IN_FLIGHT.get(cache_key) is task:
-                _DAILY_PAYLOAD_IN_FLIGHT.pop(cache_key, None)
+        async with lock:
+            if in_flight.get(cache_key) is task:
+                in_flight.pop(cache_key, None)
 
     if payload:
-        async with _DAILY_PAYLOAD_LOCK:
-            _DAILY_PAYLOAD_CACHE[cache_key] = (time.monotonic(), payload)
+        async with lock:
+            inserted_at = time.monotonic()
+            _prune_expired_daily_payloads(cache, inserted_at)
+            cache[cache_key] = (inserted_at, payload)
             actual_date = payload.get("resolved_date")
             if actual_date and actual_date != resolved_date:
-                _DAILY_PAYLOAD_CACHE[(domain, actual_date)] = (time.monotonic(), payload)
+                cache[(domain, actual_date)] = (inserted_at, payload)
     return payload
 
 
@@ -1044,7 +1080,7 @@ async def send_daily_challenge(
             bot=bot,
             domain=domain,
             is_daily=True,
-            date_str=date_str,
+            date_str=date_str or payload.get("resolved_date"),
             history_problems=payload["history_problems"],
             locale=locale,
         )

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -927,6 +927,7 @@ def create_inspiration_embed(
 
 
 _DAILY_PAYLOAD_CACHE_TTL_SECONDS = 60
+_CURRENT_DAILY_PAYLOAD_KEY = "__current__"
 
 
 def _get_daily_payload_state(
@@ -1008,9 +1009,17 @@ async def _fetch_daily_payload(
 
 
 async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None = None) -> dict[str, Any] | None:
-    resolved_date = date_str or datetime.now(pytz.UTC).strftime("%Y-%m-%d")
-    cache_key = (domain, resolved_date)
+    fallback_date = datetime.now(pytz.UTC).strftime("%Y-%m-%d")
+    cache_key = (domain, date_str or _CURRENT_DAILY_PAYLOAD_KEY)
     cache, in_flight, lock = _get_daily_payload_state(bot)
+
+    async def cleanup_in_flight(completed_task: asyncio.Task) -> None:
+        async with lock:
+            if in_flight.get(cache_key) is completed_task:
+                in_flight.pop(cache_key, None)
+
+    def schedule_cleanup(completed_task: asyncio.Task) -> None:
+        asyncio.create_task(cleanup_in_flight(completed_task))
 
     async with lock:
         now = time.monotonic()
@@ -1022,15 +1031,11 @@ async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None 
 
         task = in_flight.get(cache_key)
         if task is None:
-            task = asyncio.create_task(_fetch_daily_payload(bot, domain, date_str, resolved_date))
+            task = asyncio.create_task(_fetch_daily_payload(bot, domain, date_str, fallback_date))
+            task.add_done_callback(schedule_cleanup)
             in_flight[cache_key] = task
 
-    try:
-        payload = await task
-    finally:
-        async with lock:
-            if in_flight.get(cache_key) is task:
-                in_flight.pop(cache_key, None)
+    payload = await asyncio.shield(task)
 
     if payload:
         async with lock:
@@ -1038,7 +1043,7 @@ async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None 
             _prune_expired_daily_payloads(cache, inserted_at)
             cache[cache_key] = (inserted_at, payload)
             actual_date = payload.get("resolved_date")
-            if actual_date and actual_date != resolved_date:
+            if actual_date and (date_str or payload["challenge_info"].get("date")):
                 cache[(domain, actual_date)] = (inserted_at, payload)
     return payload
 

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -1010,16 +1010,17 @@ async def _fetch_daily_payload(
 
 async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None = None) -> dict[str, Any] | None:
     fallback_date = datetime.now(pytz.UTC).strftime("%Y-%m-%d")
-    cache_key = (domain, date_str or _CURRENT_DAILY_PAYLOAD_KEY)
+    cache_key = (domain, date_str or f"{_CURRENT_DAILY_PAYLOAD_KEY}:{fallback_date}")
     cache, in_flight, lock = _get_daily_payload_state(bot)
 
-    async def cleanup_in_flight(completed_task: asyncio.Task) -> None:
-        async with lock:
-            if in_flight.get(cache_key) is completed_task:
-                in_flight.pop(cache_key, None)
-
-    def schedule_cleanup(completed_task: asyncio.Task) -> None:
-        asyncio.create_task(cleanup_in_flight(completed_task))
+    async def fetch_and_cleanup() -> dict[str, Any] | None:
+        try:
+            return await _fetch_daily_payload(bot, domain, date_str, fallback_date)
+        finally:
+            current_task = asyncio.current_task()
+            async with lock:
+                if in_flight.get(cache_key) is current_task:
+                    in_flight.pop(cache_key, None)
 
     async with lock:
         now = time.monotonic()
@@ -1030,9 +1031,11 @@ async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None 
             return cached[1]
 
         task = in_flight.get(cache_key)
+        if task is not None and task.done():
+            in_flight.pop(cache_key, None)
+            task = None
         if task is None:
-            task = asyncio.create_task(_fetch_daily_payload(bot, domain, date_str, fallback_date))
-            task.add_done_callback(schedule_cleanup)
+            task = asyncio.create_task(fetch_and_cleanup())
             in_flight[cache_key] = task
 
     payload = await asyncio.shield(task)

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import logging
 import re
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -925,6 +926,12 @@ def create_inspiration_embed(
     return embed
 
 
+_DAILY_PAYLOAD_CACHE_TTL_SECONDS = 60
+_DAILY_PAYLOAD_CACHE: dict[tuple[str, str], tuple[float, dict[str, Any]]] = {}
+_DAILY_PAYLOAD_IN_FLIGHT: dict[tuple[str, str], asyncio.Task] = {}
+_DAILY_PAYLOAD_LOCK = asyncio.Lock()
+
+
 async def _fetch_daily_history(bot: Any, domain: str, anchor_date: str) -> List[Dict[str, Any]]:
     """Fetch daily challenge history for the same day in previous years."""
     try:
@@ -947,6 +954,59 @@ async def _fetch_daily_history(bot: Any, domain: str, anchor_date: str) -> List[
     return [r for r in results if r]
 
 
+async def _fetch_daily_payload(
+    bot: Any,
+    domain: str,
+    date_str: str | None,
+    fallback_date: str,
+) -> dict[str, Any] | None:
+    if date_str:
+        challenge_info = await bot.api.get_daily(domain, date_str)
+    else:
+        challenge_info = await bot.api.get_daily(domain)
+    if not challenge_info:
+        return None
+
+    history_anchor = challenge_info.get("date") or date_str or fallback_date
+    history_problems = await _fetch_daily_history(bot, domain, history_anchor)
+    return {
+        "challenge_info": challenge_info,
+        "history_problems": history_problems,
+        "resolved_date": history_anchor,
+    }
+
+
+async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None = None) -> dict[str, Any] | None:
+    resolved_date = date_str or datetime.now(pytz.UTC).strftime("%Y-%m-%d")
+    cache_key = (domain, resolved_date)
+    now = time.monotonic()
+
+    async with _DAILY_PAYLOAD_LOCK:
+        cached = _DAILY_PAYLOAD_CACHE.get(cache_key)
+        if cached and now - cached[0] < _DAILY_PAYLOAD_CACHE_TTL_SECONDS:
+            return cached[1]
+
+        task = _DAILY_PAYLOAD_IN_FLIGHT.get(cache_key)
+        if task is None:
+            task = asyncio.create_task(_fetch_daily_payload(bot, domain, date_str, resolved_date))
+            _DAILY_PAYLOAD_IN_FLIGHT[cache_key] = task
+
+    try:
+        payload = await task
+    finally:
+        async with _DAILY_PAYLOAD_LOCK:
+            if _DAILY_PAYLOAD_IN_FLIGHT.get(cache_key) is task:
+                _DAILY_PAYLOAD_IN_FLIGHT.pop(cache_key, None)
+
+    if payload:
+        async with _DAILY_PAYLOAD_LOCK:
+            _DAILY_PAYLOAD_CACHE[cache_key] = (time.monotonic(), payload)
+            actual_date = payload.get("resolved_date")
+            if actual_date and actual_date != resolved_date:
+                _DAILY_PAYLOAD_CACHE[(domain, actual_date)] = (time.monotonic(), payload)
+    return payload
+
+
 async def send_daily_challenge(
     bot: Any,
     channel_id: int = None,
@@ -955,6 +1015,7 @@ async def send_daily_challenge(
     domain: str = "com",
     ephemeral: bool = True,
     guild_locale: str = None,
+    date_str: str | None = None,
 ):
     """Fetches and sends the daily challenge via API."""
     if interaction:
@@ -968,28 +1029,23 @@ async def send_daily_challenge(
     try:
         logger.info("Attempting to send daily challenge. Domain: %s, Channel: %s", domain, channel_id)
 
-        now_utc = datetime.now(pytz.UTC)
-        date_str = now_utc.strftime("%Y-%m-%d")
-
-        challenge_info = await bot.api.get_daily(domain)
-
-        if not challenge_info:
+        payload = await get_daily_payload(bot, domain, date_str)
+        if not payload:
             logger.error("No daily challenge for domain %s", domain)
             if interaction:
                 await interaction.followup.send(i18n.t("ui.embed.not_found", locale), ephemeral=ephemeral)
             return None
 
+        challenge_info = payload["challenge_info"]
         logger.info("Got daily challenge: %s. %s for domain %s", challenge_info["id"], challenge_info["title"], domain)
-
-        history_anchor = challenge_info.get("date") or date_str
-        history_problems = await _fetch_daily_history(bot, domain, history_anchor)
 
         embed = await create_problem_embed(
             problem_info=challenge_info,
             bot=bot,
             domain=domain,
             is_daily=True,
-            history_problems=history_problems,
+            date_str=date_str,
+            history_problems=payload["history_problems"],
             locale=locale,
         )
         view = await create_problem_view(problem_info=challenge_info, bot=bot, domain=domain, locale=locale)

--- a/tests/test_daily_payload_reuse.py
+++ b/tests/test_daily_payload_reuse.py
@@ -1,22 +1,15 @@
 import asyncio
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
+import pytz
 from discord.ext import commands
 
 from bot.utils import ui_helpers
 from bot.utils.ui_helpers import get_daily_payload, send_daily_challenge
-
-
-@pytest.fixture(autouse=True)
-def clear_daily_payload_state():
-    ui_helpers._DAILY_PAYLOAD_CACHE.clear()
-    ui_helpers._DAILY_PAYLOAD_IN_FLIGHT.clear()
-    yield
-    ui_helpers._DAILY_PAYLOAD_CACHE.clear()
-    ui_helpers._DAILY_PAYLOAD_IN_FLIGHT.clear()
 
 
 def _daily_problem(date: str = "2026-06-03") -> dict:
@@ -96,6 +89,58 @@ async def test_get_daily_payload_reuses_short_lived_cache(monkeypatch):
 
     assert first_payload is second_payload
     assert bot.api.get_daily.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_daily_payload_cache_is_scoped_to_bot_instance(monkeypatch):
+    first_bot = _make_bot()
+    second_bot = _make_bot()
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+
+    await get_daily_payload(first_bot, "com", "2026-06-03")
+    await get_daily_payload(second_bot, "com", "2026-06-03")
+
+    assert first_bot.api.get_daily.await_count == 1
+    assert second_bot.api.get_daily.await_count == 1
+    assert first_bot._daily_payload_cache is not second_bot._daily_payload_cache
+
+
+@pytest.mark.asyncio
+async def test_get_daily_payload_prunes_expired_cache_entries(monkeypatch):
+    bot = _make_bot()
+    old_payload = {
+        "challenge_info": _daily_problem("2026-06-01"),
+        "history_problems": [],
+        "resolved_date": "2026-06-01",
+    }
+    bot._daily_payload_cache = {("com", "2026-06-01"): (0.0, old_payload)}
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    monkeypatch.setattr(ui_helpers.time, "monotonic", lambda: 61.0)
+
+    await get_daily_payload(bot, "com", "2026-06-03")
+
+    assert ("com", "2026-06-01") not in bot._daily_payload_cache
+    assert ("com", "2026-06-03") in bot._daily_payload_cache
+
+
+@pytest.mark.asyncio
+async def test_send_daily_challenge_uses_resolved_date_when_api_omits_date(monkeypatch):
+    bot = _make_bot()
+    problem = _daily_problem()
+    problem.pop("date")
+    bot.api.get_daily.return_value = problem
+    fixed_now = datetime(2026, 6, 3, tzinfo=pytz.UTC)
+    monkeypatch.setattr(ui_helpers, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    bot.i18n.t = MagicMock(
+        side_effect=lambda key, locale, **kwargs: f"Daily | {kwargs['date']}" if key == "ui.embed.daily_footer" else key
+    )
+    interaction = _make_interaction()
+
+    await send_daily_challenge(bot=bot, interaction=interaction, domain="com", ephemeral=True)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.footer.text == "Daily | 2026-06-03"
 
 
 @pytest.mark.asyncio

--- a/tests/test_daily_payload_reuse.py
+++ b/tests/test_daily_payload_reuse.py
@@ -1,0 +1,115 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord.ext import commands
+
+from bot.utils import ui_helpers
+from bot.utils.ui_helpers import get_daily_payload, send_daily_challenge
+
+
+@pytest.fixture(autouse=True)
+def clear_daily_payload_state():
+    ui_helpers._DAILY_PAYLOAD_CACHE.clear()
+    ui_helpers._DAILY_PAYLOAD_IN_FLIGHT.clear()
+    yield
+    ui_helpers._DAILY_PAYLOAD_CACHE.clear()
+    ui_helpers._DAILY_PAYLOAD_IN_FLIGHT.clear()
+
+
+def _daily_problem(date: str = "2026-06-03") -> dict:
+    return {
+        "id": "1",
+        "source": "leetcode",
+        "slug": "two-sum",
+        "title": "Two Sum",
+        "difficulty": "Easy",
+        "ac_rate": 52.34,
+        "rating": 1234,
+        "tags": ["Array"],
+        "link": "https://leetcode.com/problems/two-sum/",
+        "date": date,
+    }
+
+
+def _make_bot():
+    bot = MagicMock(spec=commands.Bot)
+    bot.api = SimpleNamespace(get_daily=AsyncMock(return_value=_daily_problem()))
+    bot.llm = MagicMock()
+    bot.llm_pro = MagicMock()
+    bot.config = SimpleNamespace(default_locale="zh-TW")
+    bot.i18n = MagicMock()
+    bot.i18n.resolve_locale = MagicMock(return_value="zh-TW")
+    bot.i18n.t = MagicMock(side_effect=lambda key, locale, **kwargs: key.format(**kwargs))
+    return bot
+
+
+def _make_interaction():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 123
+    interaction.guild_locale = None
+    interaction.locale = discord.Locale.taiwan_chinese
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_get_daily_payload_coalesces_concurrent_identical_requests(monkeypatch):
+    bot = _make_bot()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def fetch_daily(domain, date=None):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _daily_problem(date or "2026-06-03")
+
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    bot.api.get_daily.side_effect = fetch_daily
+
+    first = asyncio.create_task(get_daily_payload(bot, "com", "2026-06-03"))
+    await started.wait()
+    second = asyncio.create_task(get_daily_payload(bot, "com", "2026-06-03"))
+    release.set()
+
+    first_payload, second_payload = await asyncio.gather(first, second)
+
+    assert first_payload is second_payload
+    assert first_payload["challenge_info"]["id"] == "1"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_daily_payload_reuses_short_lived_cache(monkeypatch):
+    bot = _make_bot()
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+
+    first_payload = await get_daily_payload(bot, "com", "2026-06-03")
+    second_payload = await get_daily_payload(bot, "com", "2026-06-03")
+
+    assert first_payload is second_payload
+    assert bot.api.get_daily.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_daily_challenge_sends_each_manual_response_from_cached_payload(monkeypatch):
+    bot = _make_bot()
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    first_interaction = _make_interaction()
+    second_interaction = _make_interaction()
+
+    await send_daily_challenge(bot=bot, interaction=first_interaction, domain="com", ephemeral=True)
+    await send_daily_challenge(bot=bot, interaction=second_interaction, domain="com", ephemeral=False)
+
+    assert bot.api.get_daily.await_count == 1
+    first_interaction.followup.send.assert_awaited_once()
+    second_interaction.followup.send.assert_awaited_once()
+    assert first_interaction.followup.send.await_args.kwargs["ephemeral"] is True
+    assert second_interaction.followup.send.await_args.kwargs["ephemeral"] is False

--- a/tests/test_daily_payload_reuse.py
+++ b/tests/test_daily_payload_reuse.py
@@ -8,6 +8,7 @@ import pytest
 import pytz
 from discord.ext import commands
 
+from bot.api_client import ApiProcessingError
 from bot.utils import ui_helpers
 from bot.utils.ui_helpers import get_daily_payload, send_daily_challenge
 
@@ -88,6 +89,52 @@ async def test_get_daily_payload_reuses_short_lived_cache(monkeypatch):
     second_payload = await get_daily_payload(bot, "com", "2026-06-03")
 
     assert first_payload is second_payload
+    assert bot.api.get_daily.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_current_daily_payload_cache_is_scoped_to_fallback_date(monkeypatch):
+    bot = _make_bot()
+    dates = iter(
+        [
+            datetime(2026, 6, 2, tzinfo=pytz.UTC),
+            datetime(2026, 6, 3, tzinfo=pytz.UTC),
+        ]
+    )
+    fetched_dates = iter(["2026-06-02", "2026-06-03"])
+    monkeypatch.setattr(ui_helpers, "datetime", SimpleNamespace(now=lambda tz=None: next(dates)))
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+
+    async def fetch_daily(domain, date=None):
+        return _daily_problem(next(fetched_dates))
+
+    bot.api.get_daily.side_effect = fetch_daily
+
+    first_payload = await get_daily_payload(bot, "com")
+    second_payload = await get_daily_payload(bot, "com")
+
+    assert first_payload["resolved_date"] == "2026-06-02"
+    assert second_payload["resolved_date"] == "2026-06-03"
+    assert bot.api.get_daily.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_daily_payload_ignores_completed_failed_in_flight_task(monkeypatch):
+    bot = _make_bot()
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+
+    async def failed_fetch():
+        raise ApiProcessingError("processing")
+
+    failed_task = asyncio.create_task(failed_fetch())
+    with pytest.raises(ApiProcessingError):
+        await failed_task
+
+    bot._daily_payload_in_flight = {("com", "2026-06-03"): failed_task}
+
+    payload = await get_daily_payload(bot, "com", "2026-06-03")
+
+    assert payload["challenge_info"]["id"] == "1"
     assert bot.api.get_daily.await_count == 1
 
 

--- a/tests/test_daily_payload_reuse.py
+++ b/tests/test_daily_payload_reuse.py
@@ -158,3 +158,61 @@ async def test_send_daily_challenge_sends_each_manual_response_from_cached_paylo
     second_interaction.followup.send.assert_awaited_once()
     assert first_interaction.followup.send.await_args.kwargs["ephemeral"] is True
     assert second_interaction.followup.send.await_args.kwargs["ephemeral"] is False
+
+
+@pytest.mark.asyncio
+async def test_current_daily_payload_does_not_pollute_explicit_fallback_date(monkeypatch):
+    bot = _make_bot()
+    fixed_now = datetime(2026, 6, 2, tzinfo=pytz.UTC)
+    calls = []
+
+    async def fetch_daily(domain, date=None):
+        calls.append(date)
+        problem = _daily_problem(date or "2026-06-02")
+        problem["title"] = "Current" if date is None else "Explicit"
+        if date is None:
+            problem.pop("date")
+        return problem
+
+    monkeypatch.setattr(ui_helpers, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    bot.api.get_daily.side_effect = fetch_daily
+
+    current_payload = await get_daily_payload(bot, "com")
+    explicit_payload = await get_daily_payload(bot, "com", "2026-06-02")
+
+    assert current_payload["challenge_info"]["title"] == "Current"
+    assert explicit_payload["challenge_info"]["title"] == "Explicit"
+    assert calls == [None, "2026-06-02"]
+
+
+@pytest.mark.asyncio
+async def test_get_daily_payload_shields_shared_fetch_from_waiter_cancellation(monkeypatch):
+    bot = _make_bot()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def fetch_daily(domain, date=None):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _daily_problem(date or "2026-06-03")
+
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    bot.api.get_daily.side_effect = fetch_daily
+
+    first = asyncio.create_task(get_daily_payload(bot, "com"))
+    await started.wait()
+    second = asyncio.create_task(get_daily_payload(bot, "com"))
+    first.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    release.set()
+    payload = await second
+
+    assert payload["challenge_info"]["id"] == "1"
+    assert calls == 1

--- a/tests/test_schedule_manager_cog.py
+++ b/tests/test_schedule_manager_cog.py
@@ -1,8 +1,10 @@
 import asyncio
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+import pytz
 from discord.ext import commands
 
 from bot.cogs import schedule_manager_cog as schedule_module
@@ -70,6 +72,25 @@ async def test_duplicate_scheduled_delivery_is_skipped(monkeypatch):
 
     assert send_calls == 1
     assert cog.scheduled_deliveries_in_progress == set()
+
+
+@pytest.mark.asyncio
+async def test_scheduled_delivery_passes_guard_date_to_sender(monkeypatch):
+    cog = ScheduleManagerCog(_make_bot())
+    fixed_now = datetime(2026, 6, 3, tzinfo=pytz.UTC)
+    sent_kwargs = None
+
+    async def send_daily_challenge(**kwargs):
+        nonlocal sent_kwargs
+        sent_kwargs = kwargs
+        return {"title": "Two Sum"}
+
+    monkeypatch.setattr(schedule_module, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
+    monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
+
+    await cog.send_daily_challenge_job(123, 456, 789)
+
+    assert sent_kwargs["date_str"] == "2026-06-03"
 
 
 @pytest.mark.asyncio

--- a/tests/test_schedule_manager_cog.py
+++ b/tests/test_schedule_manager_cog.py
@@ -75,9 +75,9 @@ async def test_duplicate_scheduled_delivery_is_skipped(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_scheduled_delivery_passes_guard_date_to_sender(monkeypatch):
+async def test_scheduled_delivery_uses_configured_timezone_date(monkeypatch):
     cog = ScheduleManagerCog(_make_bot())
-    fixed_now = datetime(2026, 6, 3, tzinfo=pytz.UTC)
+    fixed_utc = datetime(2026, 6, 2, 16, tzinfo=pytz.UTC)
     sent_kwargs = None
 
     async def send_daily_challenge(**kwargs):
@@ -85,10 +85,10 @@ async def test_scheduled_delivery_passes_guard_date_to_sender(monkeypatch):
         sent_kwargs = kwargs
         return {"title": "Two Sum"}
 
-    monkeypatch.setattr(schedule_module, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
+    monkeypatch.setattr(schedule_module, "datetime", SimpleNamespace(now=lambda tz=None: fixed_utc.astimezone(tz)))
     monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
 
-    await cog.send_daily_challenge_job(123, 456, 789)
+    await cog.send_daily_challenge_job(123, 456, 789, "Asia/Taipei")
 
     assert sent_kwargs["date_str"] == "2026-06-03"
 

--- a/tests/test_schedule_manager_cog.py
+++ b/tests/test_schedule_manager_cog.py
@@ -1,0 +1,89 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from discord.ext import commands
+
+from bot.cogs import schedule_manager_cog as schedule_module
+from bot.cogs.schedule_manager_cog import ScheduleManagerCog
+
+
+def _make_bot():
+    bot = MagicMock(spec=commands.Bot)
+    bot.config = SimpleNamespace(default_locale="zh-TW")
+    bot.i18n = MagicMock()
+    bot.i18n.resolve_locale = MagicMock(return_value="zh-TW")
+    return bot
+
+
+def test_scheduler_job_defaults_prevent_overlapping_daily_jobs():
+    cog = ScheduleManagerCog(_make_bot())
+
+    assert cog.scheduler._job_defaults["coalesce"] is True
+    assert cog.scheduler._job_defaults["max_instances"] == 1
+    assert cog.scheduler._job_defaults["misfire_grace_time"] == 300
+
+
+@pytest.mark.asyncio
+async def test_add_server_schedule_keeps_misfire_grace_time(monkeypatch):
+    cog = ScheduleManagerCog(_make_bot())
+    add_job = MagicMock()
+    monkeypatch.setattr(cog.scheduler, "add_job", add_job)
+    monkeypatch.setattr(cog.scheduler, "get_job", MagicMock(return_value=None))
+
+    await cog.add_server_schedule(
+        {
+            "server_id": 123,
+            "channel_id": 456,
+            "role_id": 789,
+            "post_time": "09:30",
+            "timezone": "UTC",
+        }
+    )
+
+    assert add_job.call_args.kwargs["misfire_grace_time"] == 300
+    assert add_job.call_args.kwargs["id"] == "daily_challenge_123"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_scheduled_delivery_is_skipped(monkeypatch):
+    cog = ScheduleManagerCog(_make_bot())
+    release = asyncio.Event()
+    send_calls = 0
+
+    async def send_daily_challenge(**kwargs):
+        nonlocal send_calls
+        send_calls += 1
+        await release.wait()
+        return {"title": "Two Sum"}
+
+    monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
+
+    first = asyncio.create_task(cog.send_daily_challenge_job(123, 456, 789))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(cog.send_daily_challenge_job(123, 456, 789))
+    await asyncio.sleep(0)
+    release.set()
+
+    await asyncio.gather(first, second)
+
+    assert send_calls == 1
+    assert cog.scheduled_deliveries_in_progress == set()
+
+
+@pytest.mark.asyncio
+async def test_scheduled_delivery_guard_cleans_up_after_exception(monkeypatch):
+    cog = ScheduleManagerCog(_make_bot())
+
+    async def send_daily_challenge(**kwargs):
+        raise RuntimeError("discord send failed")
+
+    monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
+
+    await cog.send_daily_challenge_job(123, 456, 789)
+
+    assert cog.scheduled_deliveries_in_progress == set()
+
+    await cog.send_daily_challenge_job(123, 456, 789)
+    assert cog.scheduled_deliveries_in_progress == set()

--- a/tests/test_schedule_manager_cog.py
+++ b/tests/test_schedule_manager_cog.py
@@ -75,7 +75,7 @@ async def test_duplicate_scheduled_delivery_is_skipped(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_scheduled_delivery_uses_configured_timezone_date(monkeypatch):
+async def test_scheduled_delivery_uses_current_daily_request(monkeypatch):
     cog = ScheduleManagerCog(_make_bot())
     fixed_utc = datetime(2026, 6, 2, 16, tzinfo=pytz.UTC)
     sent_kwargs = None
@@ -83,6 +83,7 @@ async def test_scheduled_delivery_uses_configured_timezone_date(monkeypatch):
     async def send_daily_challenge(**kwargs):
         nonlocal sent_kwargs
         sent_kwargs = kwargs
+        assert cog.scheduled_deliveries_in_progress == {(123, 456, "com", "2026-06-03")}
         return {"title": "Two Sum"}
 
     monkeypatch.setattr(schedule_module, "datetime", SimpleNamespace(now=lambda tz=None: fixed_utc.astimezone(tz)))
@@ -90,7 +91,7 @@ async def test_scheduled_delivery_uses_configured_timezone_date(monkeypatch):
 
     await cog.send_daily_challenge_job(123, 456, 789, "Asia/Taipei")
 
-    assert sent_kwargs["date_str"] == "2026-06-03"
+    assert "date_str" not in sent_kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/test_slash_problem_command.py
+++ b/tests/test_slash_problem_command.py
@@ -4,6 +4,7 @@ import discord
 import pytest
 from discord.ext import commands
 
+from bot.cogs import slash_commands_cog as slash_commands_module
 from bot.cogs.slash_commands_cog import SlashCommandsCog
 from bot.utils.ui_constants import (
     LUOGU_DIFFICULTY_COLORS,
@@ -453,3 +454,81 @@ async def test_create_problem_embed_builds_daily_similar_question_link_from_slug
 
     similar_field = next(field for field in embed.fields if field.name == "Similar Questions (1)")
     assert similar_field.value == f"- 🟡 [48. Similar Problem](https://leetcode.com/problems/{slug_value}/)"
+
+
+@pytest.mark.asyncio
+async def test_daily_command_current_delegates_to_shared_sender_with_private_response(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    send_daily = AsyncMock()
+    monkeypatch.setattr(slash_commands_module, "send_daily_challenge", send_daily)
+
+    await cog.daily_command.callback(cog, interaction, date=None, public=False)
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    send_daily.assert_awaited_once_with(bot=bot, interaction=interaction, domain="com", ephemeral=True)
+
+
+@pytest.mark.asyncio
+async def test_daily_cn_command_current_delegates_to_cn_sender(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    send_daily = AsyncMock()
+    monkeypatch.setattr(slash_commands_module, "send_daily_challenge", send_daily)
+
+    await cog.daily_cn_command.callback(cog, interaction, date=None, public=True)
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=False)
+    send_daily.assert_awaited_once_with(bot=bot, interaction=interaction, domain="cn", ephemeral=False)
+
+
+@pytest.mark.asyncio
+async def test_daily_by_date_uses_shared_payload_and_preserves_public_flag(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    payload = {
+        "challenge_info": {
+            "id": "1",
+            "source": "leetcode",
+            "slug": "two-sum",
+            "title": "Two Sum",
+            "difficulty": "Easy",
+            "ac_rate": 52.34,
+            "rating": 1234,
+            "tags": ["Array"],
+            "link": "https://leetcode.com/problems/two-sum/",
+            "date": "2026-06-03",
+        },
+        "history_problems": [],
+        "resolved_date": "2026-06-03",
+    }
+    get_payload = AsyncMock(return_value=payload)
+    monkeypatch.setattr(slash_commands_module, "get_daily_payload", get_payload)
+
+    await cog.daily_command.callback(cog, interaction, date="2026-06-03", public=True)
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=False)
+    get_payload.assert_awaited_once_with(bot, "com", "2026-06-03")
+    interaction.followup.send.assert_awaited_once()
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is False
+    assert interaction.followup.send.await_args.kwargs["embed"].footer.text == "LeetCode Daily Challenge | 2026-06-03"
+
+
+@pytest.mark.asyncio
+async def test_daily_by_date_not_found_keeps_date_specific_error(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    get_payload = AsyncMock(return_value=None)
+    monkeypatch.setattr(slash_commands_module, "get_daily_payload", get_payload)
+
+    await cog.daily_command.callback(cog, interaction, date="2026-06-03", public=False)
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    get_payload.assert_awaited_once_with(bot, "com", "2026-06-03")
+    interaction.followup.send.assert_awaited_once_with(
+        "errors.validation.not_found_for_date", ephemeral=True
+    )

--- a/tests/test_slash_problem_command.py
+++ b/tests/test_slash_problem_command.py
@@ -529,6 +529,4 @@ async def test_daily_by_date_not_found_keeps_date_specific_error(monkeypatch):
 
     interaction.response.defer.assert_awaited_once_with(ephemeral=True)
     get_payload.assert_awaited_once_with(bot, "com", "2026-06-03")
-    interaction.followup.send.assert_awaited_once_with(
-        "errors.validation.not_found_for_date", ephemeral=True
-    )
+    interaction.followup.send.assert_awaited_once_with("errors.validation.not_found_for_date", ephemeral=True)


### PR DESCRIPTION
## Summary
- prevent overlapping scheduled daily deliveries in-process
- reuse in-flight and short-lived cached daily payloads for /daily
- update OpenSpec requirements and add regression tests

## Tests
- Not run (commit-push-pr command requested commit, push, and PR only).