### PR TITLE
🐛 fix(api): sync required oj-api-rs dev contracts

### DIFF
--- a/openspec/specs/slash-commands/spec.md
+++ b/openspec/specs/slash-commands/spec.md
@@ -4,7 +4,7 @@
 TBD - created by archiving change init-project-specs. Update Purpose after archive.
 ## Requirements
 ### Requirement: Daily challenge command
-The `/daily` command SHALL fetch and display the current daily challenge from LeetCode with user-facing text localized to the resolved locale, reusing in-flight or cached daily payload data where available without suppressing valid user responses.
+The `/daily` command SHALL fetch and display the current daily challenge from LeetCode with user-facing text localized to the resolved locale, reusing in-flight or cached daily payload data where available without suppressing valid user responses. The API client SHALL expose daily data through the current `{date, source, problems}` envelope and SHALL normalize the oj-api-rs v0.4 flat response into that envelope while v0.4 remains supported.
 
 #### Scenario: Fetch today's challenge
 - **WHEN** a user runs `/daily`
@@ -17,6 +17,15 @@ The `/daily` command SHALL fetch and display the current daily challenge from Le
 #### Scenario: CN domain support
 - **WHEN** a user runs `/daily_cn`
 - **THEN** the bot SHALL fetch the daily challenge from leetcode.cn instead of leetcode.com
+
+#### Scenario: Current upstream daily response
+- **WHEN** oj-api-rs returns `{date, source, problems}` for a LeetCode daily request
+- **THEN** the existing `/daily` or `/daily_cn` flow SHALL render the first problem and preserve the envelope date for the footer and history lookup
+
+#### Scenario: oj-api-rs v0.4 daily compatibility
+- **WHEN** the configured backend returns the v0.4 flat daily problem response
+- **THEN** the API client SHALL wrap it in the current daily envelope before downstream processing
+- **AND** the compatibility normalization SHALL be observable through an informational log entry
 
 #### Scenario: Public toggle
 - **WHEN** a user runs `/daily` with the `public` parameter set to True

--- a/openspec/specs/tag-autocomplete/spec.md
+++ b/openspec/specs/tag-autocomplete/spec.md
@@ -5,11 +5,16 @@ Tags autocomplete capability for the `/random` command, providing dynamic tag su
 
 ## Requirements
 ### Requirement: Tags by source API method
-The `OjApiClient` SHALL provide a `get_tags(source)` method that retrieves the valid tag list for a given problem source via `GET /api/v1/tags/{source}`.
+The `OjApiClient` SHALL provide a `get_tags(source)` method that retrieves the valid tag list for a given problem source via `GET /api/v1/problems/tags/{source}`. While oj-api-rs v0.4 remains supported, the client SHALL retry the legacy `GET /api/v1/tags/{source}` route only when the current route is unavailable.
 
 #### Scenario: Successful tag retrieval
 - **WHEN** `get_tags("leetcode")` is called
-- **THEN** the method SHALL send a `GET /api/v1/tags/leetcode` request and return the response as a list of strings
+- **THEN** the method SHALL send a `GET /api/v1/problems/tags/leetcode` request and return the response as a list of strings
+
+#### Scenario: oj-api-rs v0.4 compatibility
+- **WHEN** `GET /api/v1/problems/tags/leetcode` is unavailable because the configured backend still uses the v0.4 route contract
+- **THEN** the method SHALL retry `GET /api/v1/tags/leetcode`
+- **AND** the compatibility fallback SHALL be observable through an informational log entry
 
 #### Scenario: Empty tag list
 - **WHEN** the API returns an empty array for a valid source

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -167,11 +167,29 @@ class OjApiClient:
     async def get_problem(self, source: str, id: str) -> dict | None:
         return await self._request("GET", f"problems/{quote(source)}/{quote(id)}")
 
+    @staticmethod
+    def _normalize_daily_response(response: dict, domain: str) -> dict:
+        if isinstance(response.get("problems"), list) or "id" not in response:
+            return response
+
+        legacy_problem = {key: value for key, value in response.items() if key not in {"date", "domain"}}
+        legacy_problem.setdefault("source", "leetcode")
+        legacy_domain = response.get("domain") or domain
+        logger.info("Normalizing oj-api-rs v0.4 daily response for domain %s", legacy_domain)
+        return {
+            "date": response.get("date"),
+            "source": "leetcode.cn" if legacy_domain == "cn" else "leetcode.com",
+            "problems": [legacy_problem],
+        }
+
     async def get_daily(self, domain: str = "com", date: str | None = None) -> dict | None:
         params = {"domain": domain}
         if date:
             params["date"] = date
-        return await self._request("GET", "daily", params=params)
+        response = await self._request("GET", "daily", params=params)
+        if response is None:
+            return None
+        return self._normalize_daily_response(response, domain)
 
     async def resolve(self, query: str) -> dict | None:
         return await self._request("GET", f"resolve/{quote(query, safe='')}")

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -250,13 +250,24 @@ class OjApiClient:
         return items[0] if items else None
 
     async def get_tags(self, source: str) -> list[str]:
-        """Fetch valid tags for a problem source via GET /api/v1/tags/{source}."""
+        """Fetch valid tags for a problem source using the current metadata route."""
+        encoded_source = quote(source)
         try:
-            response = await self._request("GET", f"tags/{quote(source)}")
+            response = await self._request("GET", f"problems/tags/{encoded_source}")
         except ApiError as e:
-            if e.status == 400:
-                return []
-            raise
+            if e.status not in {400, 404}:
+                raise
+            response = None
+
+        if response is None:
+            logger.info("Falling back to oj-api-rs v0.4 tags endpoint for source %s", source)
+            try:
+                response = await self._request("GET", f"tags/{encoded_source}")
+            except ApiError as e:
+                if e.status in {400, 404}:
+                    return []
+                raise
+
         if not response or not isinstance(response, list):
             return []
         return response

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -273,6 +273,8 @@ class OjApiClient:
         try:
             response = await self._request("GET", f"problems/tags/{encoded_source}")
         except ApiError as e:
+            if e.status == 400 and e.detail != "invalid source: tags":
+                return []
             if e.status not in {400, 404}:
                 raise
             response = None

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -997,9 +997,10 @@ async def _fetch_daily_history(bot: Any, domain: str, anchor_date: str) -> List[
 
     results = await asyncio.gather(*[fetch_one(d) for d in history_dates])
     history_problems = []
-    for response in results:
+    for requested_date, response in zip(history_dates, results):
         problem = _get_primary_daily_problem(response)
         if problem:
+            problem.setdefault("date", requested_date)
             history_problems.append(problem)
     return history_problems
 

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -930,6 +930,19 @@ _DAILY_PAYLOAD_CACHE_TTL_SECONDS = 60
 _CURRENT_DAILY_PAYLOAD_KEY = "__current__"
 
 
+def _get_primary_daily_problem(response: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not response:
+        return None
+    problems = response.get("problems")
+    if not isinstance(problems, list) or not problems or not isinstance(problems[0], dict):
+        return None
+
+    problem = dict(problems[0])
+    if response.get("date"):
+        problem["date"] = response["date"]
+    return problem
+
+
 def _get_daily_payload_state(
     bot: Any,
 ) -> tuple[dict[tuple[str, str], tuple[float, dict[str, Any]]], dict[tuple[str, str], asyncio.Task], asyncio.Lock]:
@@ -983,7 +996,12 @@ async def _fetch_daily_history(bot: Any, domain: str, anchor_date: str) -> List[
                 return None
 
     results = await asyncio.gather(*[fetch_one(d) for d in history_dates])
-    return [r for r in results if r]
+    history_problems = []
+    for response in results:
+        problem = _get_primary_daily_problem(response)
+        if problem:
+            history_problems.append(problem)
+    return history_problems
 
 
 async def _fetch_daily_payload(
@@ -993,13 +1011,14 @@ async def _fetch_daily_payload(
     fallback_date: str,
 ) -> dict[str, Any] | None:
     if date_str:
-        challenge_info = await bot.api.get_daily(domain, date_str)
+        daily_response = await bot.api.get_daily(domain, date_str)
     else:
-        challenge_info = await bot.api.get_daily(domain)
+        daily_response = await bot.api.get_daily(domain)
+    challenge_info = _get_primary_daily_problem(daily_response)
     if not challenge_info:
         return None
 
-    history_anchor = challenge_info.get("date") or date_str or fallback_date
+    history_anchor = daily_response.get("date") or date_str or fallback_date
     history_problems = await _fetch_daily_history(bot, domain, history_anchor)
     return {
         "challenge_info": challenge_info,

--- a/tests/test_daily_payload_reuse.py
+++ b/tests/test_daily_payload_reuse.py
@@ -8,7 +8,7 @@ import pytest
 import pytz
 from discord.ext import commands
 
-from bot.api_client import ApiProcessingError
+from bot.api_client import ApiProcessingError, OjApiClient
 from bot.utils import ui_helpers
 from bot.utils.ui_helpers import get_daily_payload, send_daily_challenge
 
@@ -28,9 +28,19 @@ def _daily_problem(date: str = "2026-06-03") -> dict:
     }
 
 
+def _daily_response(date: str = "2026-06-03", domain: str = "com") -> dict:
+    problem = _daily_problem(date)
+    problem.pop("date")
+    return {
+        "date": date,
+        "source": f"leetcode.{domain}",
+        "problems": [problem],
+    }
+
+
 def _make_bot():
     bot = MagicMock(spec=commands.Bot)
-    bot.api = SimpleNamespace(get_daily=AsyncMock(return_value=_daily_problem()))
+    bot.api = SimpleNamespace(get_daily=AsyncMock(return_value=_daily_response()))
     bot.llm = MagicMock()
     bot.llm_pro = MagicMock()
     bot.config = SimpleNamespace(default_locale="zh-TW")
@@ -52,6 +62,56 @@ def _make_interaction():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("domain", "daily_source"),
+    [("com", "leetcode.com"), ("cn", "leetcode.cn")],
+)
+async def test_get_daily_wraps_v040_flat_response(domain, daily_source):
+    legacy_response = {
+        "date": "2026-06-03",
+        "domain": domain,
+        "id": "1",
+        "slug": "two-sum",
+        "title": "Two Sum",
+        "title_cn": "兩數之和",
+    }
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=legacy_response)
+
+    result = await api.get_daily(domain, "2026-06-03")
+
+    assert result == {
+        "date": "2026-06-03",
+        "source": daily_source,
+        "problems": [
+            {
+                "id": "1",
+                "source": "leetcode",
+                "slug": "two-sum",
+                "title": "Two Sum",
+                "title_cn": "兩數之和",
+            }
+        ],
+    }
+    assert legacy_response["domain"] == domain
+    api._request.assert_awaited_once_with("GET", "daily", params={"domain": domain, "date": "2026-06-03"})
+
+
+@pytest.mark.asyncio
+async def test_get_daily_preserves_current_envelope_response():
+    current_response = _daily_response()
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=current_response)
+
+    result = await api.get_daily("com")
+
+    assert result is current_response
+    api._request.assert_awaited_once_with("GET", "daily", params={"domain": "com"})
+
+
+@pytest.mark.asyncio
 async def test_get_daily_payload_coalesces_concurrent_identical_requests(monkeypatch):
     bot = _make_bot()
     started = asyncio.Event()
@@ -63,7 +123,7 @@ async def test_get_daily_payload_coalesces_concurrent_identical_requests(monkeyp
         calls += 1
         started.set()
         await release.wait()
-        return _daily_problem(date or "2026-06-03")
+        return _daily_response(date or "2026-06-03", domain)
 
     monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
     bot.api.get_daily.side_effect = fetch_daily
@@ -106,7 +166,7 @@ async def test_current_daily_payload_cache_is_scoped_to_fallback_date(monkeypatc
     monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
 
     async def fetch_daily(domain, date=None):
-        return _daily_problem(next(fetched_dates))
+        return _daily_response(next(fetched_dates), domain)
 
     bot.api.get_daily.side_effect = fetch_daily
 
@@ -173,9 +233,9 @@ async def test_get_daily_payload_prunes_expired_cache_entries(monkeypatch):
 @pytest.mark.asyncio
 async def test_send_daily_challenge_uses_resolved_date_when_api_omits_date(monkeypatch):
     bot = _make_bot()
-    problem = _daily_problem()
-    problem.pop("date")
-    bot.api.get_daily.return_value = problem
+    response = _daily_response()
+    response.pop("date")
+    bot.api.get_daily.return_value = response
     fixed_now = datetime(2026, 6, 3, tzinfo=pytz.UTC)
     monkeypatch.setattr(ui_helpers, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
     monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
@@ -215,11 +275,11 @@ async def test_current_daily_payload_does_not_pollute_explicit_fallback_date(mon
 
     async def fetch_daily(domain, date=None):
         calls.append(date)
-        problem = _daily_problem(date or "2026-06-02")
-        problem["title"] = "Current" if date is None else "Explicit"
+        response = _daily_response(date or "2026-06-02", domain)
+        response["problems"][0]["title"] = "Current" if date is None else "Explicit"
         if date is None:
-            problem.pop("date")
-        return problem
+            response.pop("date")
+        return response
 
     monkeypatch.setattr(ui_helpers, "datetime", SimpleNamespace(now=lambda tz=None: fixed_now))
     monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
@@ -245,7 +305,7 @@ async def test_get_daily_payload_shields_shared_fetch_from_waiter_cancellation(m
         calls += 1
         started.set()
         await release.wait()
-        return _daily_problem(date or "2026-06-03")
+        return _daily_response(date or "2026-06-03", domain)
 
     monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
     bot.api.get_daily.side_effect = fetch_daily

--- a/tests/test_history_dates.py
+++ b/tests/test_history_dates.py
@@ -42,7 +42,17 @@ def test_generate_history_dates_invalid_format():
 
 @pytest.mark.asyncio
 async def test_fetch_daily_history_uses_module_level_generate_history_dates():
-    bot = SimpleNamespace(api=SimpleNamespace(get_daily=AsyncMock(side_effect=lambda domain, day: {"date": day})))
+    bot = SimpleNamespace(
+        api=SimpleNamespace(
+            get_daily=AsyncMock(
+                side_effect=lambda domain, day: {
+                    "date": day,
+                    "source": f"leetcode.{domain}",
+                    "problems": [{"id": day, "source": "leetcode", "title": day}],
+                }
+            )
+        )
+    )
 
     history = await _fetch_daily_history(bot, "com", "2026-01-07")
 

--- a/tests/test_history_dates.py
+++ b/tests/test_history_dates.py
@@ -63,3 +63,29 @@ async def test_fetch_daily_history_uses_module_level_generate_history_dates():
         "2022-01-07",
         "2021-01-07",
     ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_history_uses_requested_date_when_response_omits_date():
+    responses = {}
+
+    async def get_daily(domain, day):
+        response = {
+            "source": f"leetcode.{domain}",
+            "problems": [{"id": day, "source": "leetcode", "title": day}],
+        }
+        responses[day] = response
+        return response
+
+    bot = SimpleNamespace(api=SimpleNamespace(get_daily=AsyncMock(side_effect=get_daily)))
+
+    history = await _fetch_daily_history(bot, "com", "2026-01-07")
+
+    assert [entry["date"] for entry in history] == [
+        "2025-01-07",
+        "2024-01-07",
+        "2023-01-07",
+        "2022-01-07",
+        "2021-01-07",
+    ]
+    assert all("date" not in response["problems"][0] for response in responses.values())

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import aiohttp
 import discord
@@ -650,14 +650,30 @@ async def test_get_tags_returns_list_on_200():
     result = await api.get_tags("leetcode")
 
     assert result == ["Array", "DP", "Graph"]
-    api._request.assert_awaited_once_with("GET", "tags/leetcode")
+    api._request.assert_awaited_once_with("GET", "problems/tags/leetcode")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("new_route_result", [None, ApiError(400, "invalid source: tags")])
+async def test_get_tags_falls_back_to_v040_route(new_route_result):
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(side_effect=[new_route_result, ["Array", "DP"]])
+
+    result = await api.get_tags("leetcode")
+
+    assert result == ["Array", "DP"]
+    assert api._request.await_args_list == [
+        call("GET", "problems/tags/leetcode"),
+        call("GET", "tags/leetcode"),
+    ]
 
 
 @pytest.mark.asyncio
 async def test_get_tags_returns_empty_on_400():
     api = OjApiClient("http://test")
     api._session = AsyncMock()
-    api._request = AsyncMock(side_effect=ApiError(400, "Bad Request"))
+    api._request = AsyncMock(side_effect=[ApiError(400, "Bad Request"), ApiError(400, "Bad Request")])
 
     result = await api.get_tags("invalid")
 
@@ -668,7 +684,7 @@ async def test_get_tags_returns_empty_on_400():
 async def test_get_tags_returns_empty_on_404():
     api = OjApiClient("http://test")
     api._session = AsyncMock()
-    api._request = AsyncMock(return_value=None)
+    api._request = AsyncMock(side_effect=[None, None])
 
     result = await api.get_tags("nonexistent")
 

--- a/tests/test_random_command.py
+++ b/tests/test_random_command.py
@@ -673,11 +673,12 @@ async def test_get_tags_falls_back_to_v040_route(new_route_result):
 async def test_get_tags_returns_empty_on_400():
     api = OjApiClient("http://test")
     api._session = AsyncMock()
-    api._request = AsyncMock(side_effect=[ApiError(400, "Bad Request"), ApiError(400, "Bad Request")])
+    api._request = AsyncMock(side_effect=ApiError(400, "invalid source: invalid"))
 
     result = await api.get_tags("invalid")
 
     assert result == []
+    api._request.assert_awaited_once_with("GET", "problems/tags/invalid")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- migrate tag discovery to the current `/problems/tags/{source}` endpoint with an observable oj-api-rs v0.4 fallback
- normalize legacy flat daily responses into the current `{date, source, problems}` envelope
- update daily consumers, regression tests, and OpenSpec contracts for both response versions

## Test plan

- [x] `.venv/bin/python -m pytest -q` — 209 passed
- [x] `.venv/bin/ruff check .`
- [x] `openspec validate tag-autocomplete --type spec --strict --no-interactive`
- [x] `openspec validate slash-commands --type spec --strict --no-interactive`

## Notes

`openspec validate --all --strict --no-interactive` still reports the two pre-existing `discord-ui` and `interaction-handler` specification structure errors; neither file is changed by this PR.
