### PR TITLE
✨ feat(daily): add extra daily source command

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ See `config.toml.example` for all available options.
 |---------|-------------|---------------------|
 | `/daily [date] [public]` | Display the LeetCode.com daily challenge<br>• Optional: `YYYY-MM-DD` for historical challenges<br>• Optional: `public` to show the response publicly<br>• Historical data is available from April 2020 onwards | None |
 | `/daily_cn [date] [public]` | Display the LeetCode.cn daily challenge<br>• Optional: `YYYY-MM-DD` for historical challenges<br>• Optional: `public` to show the response publicly | None |
+| `/daily_extra <source> [date] [public]` | Query daily problems from Sheep or 0x3f<br>• `source`: `sheep` or `0x3f`<br>• Optional: `YYYY-MM-DD` date<br>• Optional: `public` shows the initial response publicly<br>• Multi-problem results open as an overview; selected details are always private | None |
 | `/problem <problem_ids> [source] [domain] [public] [message] [title]` | Query one or multiple problems<br>• `problem_ids`: Single ID or comma-separated IDs<br>• Supports `source:id` format such as `atcoder:abc001_a` or `leetcode:1`<br>• `source`: Problem source filter or hint<br>• `domain`: `com` or `cn` for LeetCode (default: `com`)<br>• `public`: Show the response publicly<br>• `message`: Optional personal note (max 500 chars)<br>• `title`: Custom title for multi-problem mode (max 100 chars)<br>• Supports up to 20 problems per query | None |
 | `/recent <username> [limit] [public]` | View recent accepted submissions for a user<br>• `username`: LeetCode username (LCUS only)<br>• `limit`: Number of submissions (1-50, default: 20)<br>• `public`: Show the response publicly | None |
 | `/similar [query] [problem] [top_k] [source] [public]` | Find similar problems through the configured remote API backend<br>• `query`: Free-text query (optional when `problem` is provided)<br>• `problem`: Existing problem ID or URL<br>• `top_k`: Number of results (default: 5, capped at 20)<br>• `source`: Problem source filter<br>• `public`: Show the response publicly | None |
@@ -164,6 +165,7 @@ See `config.toml.example` for all available options.
 
 The `/problem` command supports querying multiple problems at once.
 
+When `/daily_extra` returns multiple problems, it uses overview mode. Clicking a problem ID opens a private full-problem card for that user, even when the overview is public.
 #### Overview Mode
 
 When querying multiple problems, the bot displays:
@@ -189,6 +191,9 @@ When querying multiple problems, the bot displays:
 /daily
 /daily public:true
 /daily date:2024-01-15
+/daily_extra source:0x3f date:2026-06-09
+/daily_extra source:sheep
+/daily_extra source:sheep public:true
 ```
 
 </details>

--- a/docs/aegis/BASELINE-GOVERNANCE.md
+++ b/docs/aegis/BASELINE-GOVERNANCE.md
@@ -1,0 +1,54 @@
+# Baseline Governance
+
+## 1. Baseline Roles
+- Product / Requirement Baseline: problem, accepted behavior, success evidence,
+  non-goals, workflow constraints, and approved requirement/spec intent.
+- Architecture / Runtime Boundary Baseline: canonical owner, contract,
+  source-of-truth boundary, dependency direction, compatibility, runtime-ready
+  boundary, and retirement state.
+
+## 2. Design Defect
+A confirmed error, gap, contradiction, or wrong abstraction IN the relevant
+requirement, design, or baseline.
+- Fix the defective requirement/design/baseline first.
+- Then align implementation to the corrected baseline.
+- Do NOT patch implementation around a defective baseline.
+
+## 3. Implementation Drift
+Implementation, plan, review, or documentation has deviated from a confirmed,
+correct, unchanged requirement or architecture baseline.
+- Return to baseline via the simplest stable path.
+- Do NOT "update baseline to match drift" without explicit review.
+
+## 4. Compatibility Aliases
+- Architecture Defect = architecture-scoped Design Defect.
+- Architecture Drift = architecture-scoped Implementation Drift.
+- New findings should report Design Defect / Implementation Drift plus
+  `scope: requirements | architecture | both`.
+
+## 5. Baseline Check Protocol
+Before non-trivial changes:
+1. Read the latest Product / Requirement Baseline candidate.
+2. Read the latest Architecture / Runtime Boundary Baseline candidate.
+3. Compare current work against requirement acceptance and architecture owner /
+   contract boundaries.
+4. Check for new anti-patterns not recorded in known list.
+5. Report: aligned / Design Defect / Implementation Drift /
+   missing-authority / needs-clarification, with
+   `scope: requirements | architecture | both`.
+
+## 6. Architecture Review - 7 Dimensions
+After each non-trivial change:
+1. **Ownership integrity** - every component has exactly one canonical owner
+2. **Module boundaries** - no unauthorized cross-module coupling
+3. **Contract changes** - all API/signature/behavior contract changes documented
+4. **Cascade proliferation** - no new cascading dependency chains
+5. **Dependency direction** - dependencies flow toward stability
+6. **Retirement completeness** - old owners/fallbacks/paths removed or scheduled
+7. **Entropy flow** - net complexity decreased or stayed; no unjustified new entities
+
+## 7. Hard Boundaries
+- BASELINE-GOVERNANCE.md is the constitution for THIS project's Aegis workspace
+- Baseline snapshots in `baseline/` are evidence, not authority
+- ADRs in `adr/` record decisions; they do not replace baseline governance
+- This file is NEVER auto-updated - changes require explicit user review

--- a/docs/aegis/INDEX.md
+++ b/docs/aegis/INDEX.md
@@ -1,0 +1,27 @@
+# Aegis Workspace Index
+
+This index tracks files created under this project's `docs/aegis/` workspace.
+Entries are workspace records, not authoritative runtime decisions.
+
+| Date | Kind | Path | Title |
+| --- | --- | --- | --- |
+| 2026-07-16 | plan | docs/aegis/plans/2026-07-16-add-daily-extra-command.md | /daily_extra implementation plan |
+| 2026-07-16 | work | docs/aegis/work/2026-07-16-implement-daily-extra-command/10-intent.md | Implement /daily_extra command intent |
+| 2026-07-16 | work | docs/aegis/work/2026-07-16-implement-daily-extra-command/20-checkpoint.md | Implement /daily_extra command checkpoint |
+| 2026-07-16 | work | docs/aegis/work/2026-07-16-implement-daily-extra-command/90-evidence.md | Implement /daily_extra command evidence |
+| 2026-07-16 | work | docs/aegis/work/2026-07-16-implement-daily-extra-command/99-reflection.md | Implement /daily_extra command reflection |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/task-intent-draft.json | Implement /daily_extra command task intent draft |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/baseline-read-set-hint.json | Implement /daily_extra command baseline read-set hint |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/baseline-usage-draft.json | Implement /daily_extra command baseline usage draft |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/impact-statement-draft.json | Implement /daily_extra command impact statement draft |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/todo-checkpoint-draft.json | Implement /daily_extra command todo checkpoint draft |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/drift-check-draft.json | Implement /daily_extra command drift check draft |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/resume-state-hint.json | 2026-07-16-implement-daily-extra-command resume state hint |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task1-focused-tests.json | 2026-07-16-implement-daily-extra-command evidence task1-focused-tests |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task2-focused-tests.json | 2026-07-16-implement-daily-extra-command evidence task2-focused-tests |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task3-command-tests.json | 2026-07-16-implement-daily-extra-command evidence task3-command-tests |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-focused-tests.json | 2026-07-16-implement-daily-extra-command evidence final-focused-tests |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-static-spec-checks.json | 2026-07-16-implement-daily-extra-command evidence final-static-spec-checks |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-full-suite-baseline.json | 2026-07-16-implement-daily-extra-command evidence full-suite-baseline |
+| 2026-07-16 | artifact | docs/aegis/work/2026-07-16-implement-daily-extra-command/gate-input-pack.json | 2026-07-16-implement-daily-extra-command gate input pack |
+| 2026-07-16 | work | docs/aegis/work/2026-07-16-implement-daily-extra-command/proof-bundle.md | 2026-07-16-implement-daily-extra-command proof bundle |

--- a/docs/aegis/README.md
+++ b/docs/aegis/README.md
@@ -1,0 +1,10 @@
+# Aegis Project Workspace
+
+This directory stores project-local Aegis method-pack records.
+
+It may contain task intent, baseline snapshots, specs, plans, work checkpoints,
+evidence notes, and reflection records for this project.
+
+These files are advisory method-pack artifacts. They do not grant completion
+authority, produce authoritative `GateDecision`, or replace this project's
+existing authority docs.

--- a/docs/aegis/plans/2026-07-16-add-daily-extra-command.md
+++ b/docs/aegis/plans/2026-07-16-add-daily-extra-command.md
@@ -1,0 +1,1493 @@
+# /daily_extra Implementation Plan
+
+## Goal
+
+Implement the approved manual /daily_extra command for Sheep and 0x3f daily sources, preserving ordered multi-problem envelopes, showing an overview before details, and keeping every selected detail ephemeral.
+
+## Architecture
+
+Keep the existing owners and compose them:
+
+- OjApiClient owns upstream request parameters and response envelopes.
+- get_daily_payload() owns process-local daily payload coalescing and cache identity.
+- ui_helpers owns source-aware problem cards, overview embeds, and safe persistent problem-detail buttons.
+- SlashCommandsCog owns slash-command validation, visibility, orchestration, and error mapping.
+- InteractionHandlerCog remains unchanged and owns stateless problem view clicks through problem|source|id|view.
+
+The new command uses a source-only API method, while existing LeetCode callers keep get_daily(domain, date) and oj-api-rs v0.4 normalization. The payload cache uses explicit target namespaces so domains and additional sources cannot collide.
+
+## Tech Stack
+
+- Python 3.10+
+- discord.py 2.5+
+- aiohttp
+- pytest, pytest-asyncio, unittest.mock
+- Ruff
+- OpenSpec spec-driven workflow
+
+## Baseline / Authority Refs
+
+- openspec/changes/add-daily-extra-command/proposal.md
+- openspec/changes/add-daily-extra-command/design.md
+- openspec/changes/add-daily-extra-command/specs/daily-extra-command/spec.md
+- openspec/changes/add-daily-extra-command/specs/daily-request-deduplication/spec.md
+- openspec/specs/interaction-handler/spec.md
+- openspec/specs/discord-ui/spec.md
+- openspec/specs/command-localization/spec.md
+- openspec/specs/locale-files/spec.md
+- /home/usaya/workspace/github/oj-api-rs/openspec/specs/daily-challenge/spec.md at dev commit 4536487
+
+## Compatibility Boundary
+
+- Preserve OjApiClient.get_daily(domain="com", date=None).
+- Preserve v0.4 flat LeetCode daily normalization and its informational log.
+- Preserve /daily, /daily_cn, LeetCode historical lookup, and scheduled delivery.
+- Preserve the problem|source|id|view format and existing ephemeral view handler.
+- Do not add configuration fields, database schema, migrations, scheduled jobs, dependencies, or additional source values.
+- /daily_extra requires the newer oj-api-rs source query contract; a v0.4 backend may return the existing localized generic API error for this command only.
+
+## Verification
+
+Run from the repository root:
+
+    .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+      tests/test_daily_payload_reuse.py \
+      tests/test_daily_extra_command.py \
+      tests/test_slash_problem_command.py \
+      tests/test_interaction_handler.py \
+      tests/test_history_dates.py
+
+    uv run --extra dev ruff check .
+    uv run --extra dev pytest -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache
+    openspec validate add-daily-extra-command --strict --no-interactive
+    python3 /home/usaya/.codex/aegis/scripts/aegis-workspace.py check --root .
+    git diff --check
+
+Expected result: all focused and full tests pass, Ruff reports no errors, the OpenSpec change is valid, the Aegis workspace check passes, and git diff has no whitespace errors.
+
+## Aegis Visibility
+
+Planning is necessary because this public slash command crosses the API contract, cache identity, Discord interaction safety, localization, and compatibility boundaries; pinning owners and tests first prevents a caller-side source hack or a second interaction protocol.
+
+## Plan Basis
+
+- Approved behavior: dedicated manual /daily_extra; source choices Sheep and 0x3f; optional date/public; one problem opens directly; multiple problems show an overview; selected details are always private.
+- TDD Route: light. The user requested concrete test cases, so each new contract receives focused tests before its source edit, without imposing strict micro-commit TDD on unchanged compatibility surfaces.
+- ArchitectureReviewRequired: yes, because this is a public command and cross-module API/cache/UI contract change.
+
+## BaselineUsageDraft
+
+- Required baseline refs: approved OpenSpec change, existing interaction/UI/localization specs, upstream daily challenge contract.
+- Delivered context refs: current api_client.py, ui_helpers.py, slash_commands_cog.py, interaction_handler_cog.py, locale files, and focused tests.
+- Acknowledged before plan refs: all required refs above.
+- Cited in plan refs: all required refs above.
+- Missing refs: none.
+- Decision: continue.
+
+## Requirement Ready Check
+
+- Requirement source refs: approved conversation design and OpenSpec change add-daily-extra-command.
+- Goals and scope refs: proposal Why, What Changes, and design Goals / Non-Goals.
+- User / scenario refs: daily-extra-command spec scenarios.
+- Requirement item refs: six added daily-extra requirements and modified in-flight payload reuse.
+- Acceptance / verification criteria refs: OpenSpec scenarios, PBT properties, and this plan's verification section.
+- Open blocker questions: none.
+- Decision: ready.
+
+## Ripple Signal Triage
+
+- Producer: OjApiClient daily request methods.
+- Shared transformation: get_daily_payload() and its cache/in-flight keys.
+- Consumers: /daily, /daily_cn, send_daily_challenge(), scheduled delivery, and new /daily_extra.
+- UI/interaction: generic problem overview and unchanged unified view handler.
+- Localization: three locale JSON files and command translator lookup.
+- Verification expansion: focused extra-source tests plus existing LeetCode daily, history, interaction, and full-suite regression.
+- Decision: expand verification across producer, shared payload, all daily consumers, UI, and i18n.
+
+## Change Necessity
+
+- User-visible need: manually query Sheep or 0x3f daily data and safely inspect multiple returned problems.
+- No-change / non-code option: documentation alone cannot register the command, send source parameters, preserve all problems, or control Discord response visibility.
+- Why code change is necessary: existing public methods accept only LeetCode domains and downstream daily rendering selects problems[0].
+- Minimum change boundary: api_client.py, ui_helpers.py, slash_commands_cog.py, ui_constants.py, locale files, README, and focused tests.
+- Decision: code-change.
+
+## Existence Check
+
+### New slash command
+
+- Proposed new surface: /daily_extra.
+- Existing owner / reuse candidate: /daily and /daily_cn.
+- Why existing surface is insufficient: their domain semantics and scheduled LeetCode behavior are stable compatibility boundaries; overloading them would change accepted behavior.
+- Creation proof: the user approved a dedicated manual command with two explicit source choices.
+- Entropy / retirement impact: one public command; no replacement or retirement.
+- Decision: add-with-proof.
+
+### Additional-source API method
+
+- Proposed new surface: OjApiClient.get_daily_by_source().
+- Existing owner / reuse candidate: OjApiClient.get_daily(domain, date).
+- Why existing surface is insufficient: its default domain and v0.4 normalization contract make source/domain conflicts easy to introduce.
+- Creation proof: the upstream endpoint has a distinct source query contract unavailable in v0.4.
+- Entropy / retirement impact: a small sibling method; reuse the existing HTTP layer; no fallback.
+- Decision: add-with-proof.
+
+### Discord interaction protocol
+
+- Proposed new surface: daily-specific view/custom id.
+- Existing owner / reuse candidate: problem|source|id|view and InteractionHandlerCog.
+- Why existing surface is insufficient: it is sufficient.
+- Creation proof: none.
+- Entropy / retirement impact: no new state or router.
+- Decision: reuse-existing.
+
+### Test owner
+
+- Proposed new surface: tests/test_daily_extra_command.py.
+- Existing owner / reuse candidate: test_slash_problem_command.py and test_daily_payload_reuse.py.
+- Why existing surface is insufficient: the existing slash test file is already broad, while the new file can cohesively own command/UI scenarios; payload contract tests remain in the existing payload file.
+- Creation proof: the feature has a distinct public command and a multi-scenario acceptance matrix.
+- Entropy / retirement impact: one cohesive test file; remove it if the command is retired.
+- Decision: add-with-proof.
+
+## Architecture Integrity Lens
+
+- Invariant: daily payload identity is target kind + target value + date.
+- Canonical owners: API parameters in OjApiClient; cache identity in get_daily_payload(); Discord button safety in ui_helpers; command orchestration in SlashCommandsCog; click privacy in InteractionHandlerCog.
+- Responsibility overlap: avoid validating source query details in the command and avoid rebuilding custom ids outside ui_helpers.
+- Higher-level simplification: preserve one payload cache and one unified problem-detail route.
+- Retirement / falsifier: if implementation adds a daily-specific interaction handler, a second payload cache, or scheduler/config edits, it has drifted from the approved design.
+- Verdict: aligned.
+
+## Plan Pressure Test
+
+- Owner / contract / retirement: each change has one current owner; no old path is replaced.
+- Architecture integrity / higher-level path: shared payload and shared view safety are changed at their canonical owners.
+- Verification scope: producer, cache, command, UI, interaction privacy, localization, docs, and existing daily regressions are covered.
+- Task executability: every task names exact files, tests, commands, and commit boundary.
+- Pressure result: proceed.
+
+## Complexity Budget
+
+- Artifact class: source and maintained test code.
+- Target files / artifacts: ui_helpers.py (1165 lines), slash_commands_cog.py (694), api_client.py (312), test_daily_payload_reuse.py (325), new focused test file.
+- Current pressure: ui_helpers.py is near the 1200-line strong pressure threshold and already owns several UI responsibilities.
+- Projected post-change pressure: small owner-local safety/footer edits keep ui_helpers.py near but below/around the threshold; command tests go to a new cohesive file instead of enlarging a broad existing file.
+- Budget result: at-risk.
+- Planned governance: ui_helpers receives only owner-local extraction/reuse; no new view class or daily service is added. If implementation would push a cohesive touched block beyond roughly 80 lines, pause and extract the generic detail-view safety helper rather than adding command-specific checks.
+
+## Plan-Time Complexity Check
+
+- Target files: ui_helpers.py, slash_commands_cog.py, api_client.py, tests.
+- Existing size / shape signals: ui_helpers.py is large; slash_commands_cog.py is moderately large; API client is compact.
+- Owner fit: all proposed edits match current owners.
+- Add-in-place risk: command-specific UI validation in SlashCommandsCog would duplicate button safety and worsen coupling.
+- Better file boundary: generic all-or-nothing safety remains in ui_helpers; command tests use a new dedicated test file.
+- Recommendation: edit existing owners, add one focused test file, and do not add a production module.
+
+## Execution Readiness View
+
+- Intent Lock: manual /daily_extra only.
+- Scope Fence: no scheduler, DB, configuration, pagination, message editing, or new sources.
+- Baseline Lock: OpenSpec add-daily-extra-command plus existing interaction/UI/localization contracts.
+- Approved Behavior: single direct card, multiple ordered overview, public flag only for initial response, private selected details.
+- Owner / Contract Constraints: preserve get_daily() and unified problem custom ids.
+- Compatibility Boundary: existing LeetCode and v0.4 paths remain stable.
+- Retirement Boundary: no old owner retires; no fallback is added.
+- Task Batches: API/payload, UI safety, command/i18n, privacy/docs/verification.
+- Test Obligations: focused RED/GREEN tests, existing daily regressions, full suite, Ruff, OpenSpec.
+- Review Gates: review API parameter shape after Task 1 and public/private behavior after Task 3.
+- Drift / Rewind Rules: stop and return to design if implementation needs scheduler state, a new custom id, or a second cache.
+- Evidence Required Before Completion: exact command outputs, OpenSpec validity, locale parity, clean diff check, and architecture review.
+- Advisory Boundary: method-pack execution guidance only; not GateDecision, PolicySnapshot, or completion authority.
+
+## File Map
+
+Create:
+
+- tests/test_daily_extra_command.py: command, overview safety, and locale parity acceptance tests.
+
+Modify:
+
+- src/bot/api_client.py: add source-only daily method.
+- src/bot/utils/ui_helpers.py: preserve all daily problems, namespace cache targets, skip extra-source history, enforce complete safe overview views, support footer override.
+- src/bot/utils/ui_constants.py: canonical display labels for Sheep and 0x3f.
+- src/bot/cogs/slash_commands_cog.py: register and orchestrate /daily_extra.
+- src/bot/i18n/locales/zh-TW.json: source-of-truth command/runtime strings.
+- src/bot/i18n/locales/en-US.json: English parity.
+- src/bot/i18n/locales/zh-CN.json: Simplified Chinese parity.
+- tests/test_daily_payload_reuse.py: API and shared payload contract tests.
+- tests/test_interaction_handler.py: private detail characterization assertion.
+- README.md: public command usage.
+
+Do not modify:
+
+- src/bot/cogs/interaction_handler_cog.py
+- src/bot/cogs/schedule_manager_cog.py
+- database schema or migrations
+- configuration models or config.toml
+
+## Task 1: Add the source-only API method and target-aware daily payload
+
+Files:
+
+- Modify: src/bot/api_client.py
+- Modify: src/bot/utils/ui_helpers.py
+- Modify: tests/test_daily_payload_reuse.py
+
+Why:
+
+The command cannot safely use the domain-only client method, and the shared payload must retain every returned problem while preventing source/date cache collisions.
+
+Change Necessity:
+
+The source query and complete envelope do not exist in the current client/payload contracts. The minimum boundary is one sibling API method plus the existing payload/cache owner.
+
+Impact / Compatibility:
+
+Existing get_daily() callers remain unchanged. Existing payload keys challenge_info, history_problems, and resolved_date remain available; problems and daily_source are additive. LeetCode history behavior remains active only for domain targets.
+
+Verification:
+
+    .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q tests/test_daily_payload_reuse.py
+
+- [ ] 1.1 Write the failing API and payload tests.
+
+  In tests/test_daily_payload_reuse.py, extend _make_bot() so bot.api contains both methods:
+
+        bot.api = SimpleNamespace(
+            get_daily=AsyncMock(return_value=_daily_response()),
+            get_daily_by_source=AsyncMock(),
+        )
+
+  Add this helper and these tests:
+
+        def _extra_daily_response(source: str = "sheep", date: str = "2026-06-02") -> dict:
+            return {
+                "date": date,
+                "source": source,
+                "problems": [
+                    {
+                        "id": "100A",
+                        "source": "codeforces",
+                        "slug": "100A",
+                        "title": "First",
+                        "difficulty": None,
+                        "ac_rate": None,
+                        "rating": 1200,
+                        "tags": ["implementation"],
+                        "link": "https://codeforces.com/problemset/problem/100/A",
+                    },
+                    {
+                        "id": "200B",
+                        "source": "codeforces",
+                        "slug": "200B",
+                        "title": "Second",
+                        "difficulty": None,
+                        "ac_rate": None,
+                        "rating": 1400,
+                        "tags": ["math"],
+                        "link": "https://codeforces.com/problemset/problem/200/B",
+                    },
+                ],
+            }
+
+
+        @pytest.mark.asyncio
+        async def test_get_daily_by_source_sends_source_without_domain():
+            response = _extra_daily_response("sheep", "2026-06-02")
+            api = OjApiClient("http://test")
+            api._session = AsyncMock()
+            api._request = AsyncMock(return_value=response)
+
+            result = await api.get_daily_by_source("sheep", "2026-06-02")
+
+            assert result is response
+            api._request.assert_awaited_once_with(
+                "GET",
+                "daily",
+                params={"source": "sheep", "date": "2026-06-02"},
+            )
+
+
+        @pytest.mark.asyncio
+        async def test_extra_daily_payload_preserves_order_and_skips_history(monkeypatch):
+            bot = _make_bot()
+            response = _extra_daily_response()
+            bot.api.get_daily_by_source.return_value = response
+            history = AsyncMock()
+            monkeypatch.setattr(ui_helpers, "_fetch_daily_history", history)
+
+            payload = await get_daily_payload(
+                bot,
+                date_str="2026-06-02",
+                source="sheep",
+            )
+
+            assert [problem["id"] for problem in payload["problems"]] == ["100A", "200B"]
+            assert payload["challenge_info"]["id"] == "100A"
+            assert payload["daily_source"] == "sheep"
+            assert payload["resolved_date"] == "2026-06-02"
+            assert payload["history_problems"] == []
+            history.assert_not_awaited()
+            bot.api.get_daily_by_source.assert_awaited_once_with("sheep", "2026-06-02")
+
+
+        @pytest.mark.asyncio
+        async def test_daily_payload_cache_isolated_by_target(monkeypatch):
+            bot = _make_bot()
+            monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+            bot.api.get_daily_by_source.side_effect = [
+                _extra_daily_response("sheep"),
+                _extra_daily_response("0x3f"),
+            ]
+
+            leetcode = await get_daily_payload(bot, "com", "2026-06-02")
+            sheep = await get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+            zero_x3f = await get_daily_payload(bot, date_str="2026-06-02", source="0x3f")
+            sheep_again = await get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+
+            assert leetcode["daily_source"] == "leetcode.com"
+            assert sheep["daily_source"] == "sheep"
+            assert zero_x3f["daily_source"] == "0x3f"
+            assert sheep_again is sheep
+            assert bot.api.get_daily.await_count == 1
+            assert bot.api.get_daily_by_source.await_count == 2
+            assert ("domain:com", "2026-06-02") in bot._daily_payload_cache
+            assert ("source:sheep", "2026-06-02") in bot._daily_payload_cache
+            assert ("source:0x3f", "2026-06-02") in bot._daily_payload_cache
+
+
+        @pytest.mark.asyncio
+        async def test_extra_daily_payload_coalesces_identical_in_flight_requests():
+            bot = _make_bot()
+            started = asyncio.Event()
+            release = asyncio.Event()
+            calls = 0
+
+            async def fetch(source, date=None):
+                nonlocal calls
+                calls += 1
+                started.set()
+                await release.wait()
+                return _extra_daily_response(source, date or "2026-06-02")
+
+            bot.api.get_daily_by_source.side_effect = fetch
+            first = asyncio.create_task(
+                get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+            )
+            await started.wait()
+            second = asyncio.create_task(
+                get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+            )
+            release.set()
+
+            first_payload, second_payload = await asyncio.gather(first, second)
+
+            assert first_payload is second_payload
+            assert calls == 1
+
+- [ ] 1.2 Verify RED.
+
+  Run:
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q tests/test_daily_payload_reuse.py
+
+  Expected failures before implementation:
+
+  - OjApiClient has no get_daily_by_source attribute.
+  - get_daily_payload() rejects the source keyword.
+  - payloads have no problems or daily_source keys.
+  - cache keys are not target-namespaced.
+
+- [ ] 1.3 Implement the minimum API and payload changes.
+
+  Add this sibling method after get_daily() in src/bot/api_client.py:
+
+        async def get_daily_by_source(self, source: str, date: str | None = None) -> dict | None:
+            params = {"source": source}
+            if date:
+                params["date"] = date
+            return await self._request("GET", "daily", params=params)
+
+  In src/bot/utils/ui_helpers.py, add a complete-envelope extractor and keep the primary helper as a compatibility projection:
+
+        def _get_daily_problems(response: dict[str, Any] | None) -> list[dict[str, Any]] | None:
+            if not response:
+                return None
+            problems = response.get("problems")
+            if (
+                not isinstance(problems, list)
+                or not problems
+                or not all(isinstance(problem, dict) for problem in problems)
+            ):
+                return None
+
+            resolved = [dict(problem) for problem in problems]
+            if response.get("date"):
+                for problem in resolved:
+                    problem["date"] = response["date"]
+            return resolved
+
+
+        def _get_primary_daily_problem(response: dict[str, Any] | None) -> dict[str, Any] | None:
+            problems = _get_daily_problems(response)
+            return problems[0] if problems else None
+
+  Replace _fetch_daily_payload() with:
+
+        async def _fetch_daily_payload(
+            bot: Any,
+            domain: str,
+            date_str: str | None,
+            fallback_date: str,
+            *,
+            source: str | None = None,
+        ) -> dict[str, Any] | None:
+            if source is not None:
+                daily_response = await bot.api.get_daily_by_source(source, date_str)
+            elif date_str:
+                daily_response = await bot.api.get_daily(domain, date_str)
+            else:
+                daily_response = await bot.api.get_daily(domain)
+
+            problems = _get_daily_problems(daily_response)
+            if not problems:
+                return None
+
+            resolved_date = daily_response.get("date") or date_str or fallback_date
+            history_problems = (
+                [] if source is not None else await _fetch_daily_history(bot, domain, resolved_date)
+            )
+            return {
+                "challenge_info": problems[0],
+                "problems": problems,
+                "history_problems": history_problems,
+                "resolved_date": resolved_date,
+                "daily_source": daily_response.get("source")
+                or source
+                or ("leetcode.cn" if domain == "cn" else "leetcode.com"),
+            }
+
+  Change get_daily_payload() to accept source as a keyword-only target and use a namespaced key:
+
+        async def get_daily_payload(
+            bot: Any,
+            domain: str = "com",
+            date_str: str | None = None,
+            *,
+            source: str | None = None,
+        ) -> dict[str, Any] | None:
+            fallback_timezone = pytz.timezone("Asia/Taipei") if source is not None else pytz.UTC
+            fallback_date = datetime.now(fallback_timezone).strftime("%Y-%m-%d")
+            target_key = f"source:{source}" if source is not None else f"domain:{domain}"
+            cache_key = (target_key, date_str or f"{_CURRENT_DAILY_PAYLOAD_KEY}:{fallback_date}")
+            cache, in_flight, lock = _get_daily_payload_state(bot)
+
+  Preserve the existing function body, but make these exact substitutions:
+
+        return await _fetch_daily_payload(
+            bot,
+            domain,
+            date_str,
+            fallback_date,
+            source=source,
+        )
+
+        cache[(target_key, actual_date)] = (inserted_at, payload)
+
+  Update the three existing cache/in-flight fixtures and assertions in tests/test_daily_payload_reuse.py exactly:
+
+        bot._daily_payload_in_flight = {
+            ("domain:com", "2026-06-03"): failed_task
+        }
+
+        bot._daily_payload_cache = {
+            ("domain:com", "2026-06-01"): (0.0, old_payload)
+        }
+
+        assert ("domain:com", "2026-06-01") not in bot._daily_payload_cache
+        assert ("domain:com", "2026-06-03") in bot._daily_payload_cache
+
+  Keep the parametrized ("com", "leetcode.com") API-domain test data unchanged; those values are API inputs, not cache keys.
+
+- [ ] 1.4 Verify GREEN and compatibility.
+
+  Run:
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+          tests/test_daily_payload_reuse.py tests/test_history_dates.py tests/test_schedule_manager_cog.py
+
+  Expected: all tests pass; existing get_daily() request assertions remain unchanged.
+
+- [ ] 1.5 Commit the API/payload slice.
+
+  Review git diff for only the files in this task, then:
+
+        git add src/bot/api_client.py src/bot/utils/ui_helpers.py tests/test_daily_payload_reuse.py
+        git commit -m "✨ feat(api): support additional daily payloads"
+
+## Task 2: Make overview detail buttons complete and safe
+
+Files:
+
+- Modify: src/bot/utils/ui_helpers.py
+- Create: tests/test_daily_extra_command.py
+- Regression: tests/test_similar_results.py
+- Regression: tests/test_slash_problem_command.py
+
+Why:
+
+The existing overview view silently slices to 25 items and does not validate routing segments. /daily_extra must either expose every returned problem safely or reject the payload without a partial view.
+
+Change Necessity:
+
+Command-side validation would duplicate Discord custom-id ownership. The minimum stable change is a generic safety predicate in ui_helpers plus an optional overview footer.
+
+Impact / Compatibility:
+
+Existing /problem requests are capped at 20 and continue to receive a view for valid resolved problems. Similar-result behavior reuses the same safety primitive and must retain its all-or-nothing behavior.
+
+Verification:
+
+    .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+      tests/test_daily_extra_command.py tests/test_similar_results.py tests/test_slash_problem_command.py
+
+- [ ] 2.1 Write the failing overview safety tests.
+
+  Create tests/test_daily_extra_command.py with:
+
+        import discord
+
+        from bot.utils.ui_helpers import (
+            create_problems_overview_embed,
+            create_problems_overview_view,
+        )
+
+
+        def _problem(problem_id: str, *, source: str = "codeforces") -> dict:
+            return {
+                "id": problem_id,
+                "source": source,
+                "slug": problem_id,
+                "title": f"Problem {problem_id}",
+                "difficulty": None,
+                "ac_rate": None,
+                "rating": 1200,
+                "tags": ["implementation"],
+                "link": f"https://example.com/{problem_id}",
+            }
+
+
+        def test_daily_overview_view_preserves_exact_25_problem_order():
+            problems = [_problem(str(index)) for index in range(1, 26)]
+
+            view = create_problems_overview_view(problems, "com")
+
+            assert view is not None
+            assert [button.label for button in view.children] == [
+                str(index) for index in range(1, 26)
+            ]
+            assert [button.row for button in view.children[:6]] == [0, 0, 0, 0, 0, 1]
+            assert view.children[-1].row == 4
+
+
+        def test_daily_overview_view_rejects_more_than_25_problems():
+            problems = [_problem(str(index)) for index in range(1, 27)]
+
+            assert create_problems_overview_view(problems, "com") is None
+
+
+        def test_daily_overview_view_rejects_unsafe_routing_fields():
+            problems = [_problem("100A"), _problem("bad|id")]
+
+            assert create_problems_overview_view(problems, "com") is None
+
+
+        def test_daily_overview_embed_accepts_daily_footer_override():
+            problems = [_problem("100A"), _problem("200B")]
+
+            embed = create_problems_overview_embed(
+                problems,
+                "com",
+                title="Sheep Daily | 2026-06-02",
+                source_label="Sheep",
+                footer_icon_url=None,
+                footer_text="Sheep Daily | 2026-06-02",
+            )
+
+            assert isinstance(embed, discord.Embed)
+            assert embed.title == "Sheep Daily | 2026-06-02"
+            assert embed.footer.text == "Sheep Daily | 2026-06-02"
+
+- [ ] 2.2 Verify RED.
+
+  Run:
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q tests/test_daily_extra_command.py
+
+  Expected failures:
+
+  - 26 problems currently produce a partial 25-button view.
+  - unsafe segments are accepted.
+  - create_problems_overview_embed() does not accept footer_text.
+
+- [ ] 2.3 Implement shared all-or-nothing safety and footer override.
+
+  Add this generic predicate near _can_create_similar_result_view() in src/bot/utils/ui_helpers.py:
+
+        def _can_create_problem_detail_view(
+            problems: List[Dict[str, Any]],
+            *,
+            max_items: int,
+            was_truncated: bool = False,
+        ) -> bool:
+            return (
+                bool(problems)
+                and not was_truncated
+                and len(problems) <= max_items
+                and all(
+                    isinstance(problem, dict)
+                    and _is_safe_problem_button_segment(problem.get("source"))
+                    and _is_safe_problem_button_segment(
+                        problem.get("id"),
+                        max_length=MAX_BUTTON_LABEL_LENGTH,
+                    )
+                    and len(
+                        _build_problem_custom_id(
+                            problem.get("source"),
+                            problem.get("id"),
+                            "view",
+                        )
+                    )
+                    <= MAX_BUTTON_CUSTOM_ID_LENGTH
+                    for problem in problems
+                )
+            )
+
+  Replace _can_create_similar_result_view() with a delegation:
+
+        def _can_create_similar_result_view(
+            results: List[Dict[str, Any]],
+            *,
+            was_truncated: bool,
+        ) -> bool:
+            return _can_create_problem_detail_view(
+                results,
+                max_items=MAX_SIMILAR_RESULT_DETAIL_BUTTONS,
+                was_truncated=was_truncated,
+            )
+
+  Change create_problems_overview_view() to return no partial view:
+
+        def create_problems_overview_view(
+            problems: List[Dict[str, Any]],
+            domain: str,
+        ) -> discord.ui.View | None:
+            if not _can_create_problem_detail_view(
+                problems,
+                max_items=MAX_PROBLEMS_PER_OVERVIEW,
+            ):
+                return None
+
+            view = discord.ui.View()
+            for index, problem in enumerate(problems):
+                emoji = get_problem_emoji(problem)
+                source, problem_id = _normalize_problem_button_segments(
+                    problem["source"],
+                    problem["id"],
+                )
+                view.add_item(
+                    discord.ui.Button(
+                        style=discord.ButtonStyle.secondary,
+                        label=problem_id,
+                        emoji=emoji,
+                        custom_id=_build_problem_custom_id(source, problem_id, "view"),
+                        row=index // 5,
+                    )
+                )
+            return view
+
+  Add footer_text after locale in the create_problems_overview_embed() signature so all existing positional parameters remain stable:
+
+        locale: str = "zh-TW",
+        footer_text: Optional[str] = None,
+
+  Resolve the footer with:
+
+        resolved_footer_text = footer_text or (
+            i18n.t("ui.embed.problems_overview", locale, source_label=source_label)
+            if i18n
+            else f"📋 {source_label} Problems Overview"
+        )
+
+  Use resolved_footer_text in both set_footer() branches.
+
+- [ ] 2.4 Verify GREEN and existing overview consumers.
+
+  Run:
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+          tests/test_daily_extra_command.py tests/test_similar_results.py tests/test_similar_cog.py \
+          tests/test_slash_problem_command.py
+
+  Expected: new safety tests pass; existing /problem and similar-result tests remain green.
+
+- [ ] 2.5 Commit the UI safety slice.
+
+        git add src/bot/utils/ui_helpers.py tests/test_daily_extra_command.py
+        git commit -m "🐛 fix(ui): prevent partial problem overviews"
+
+## Task 3: Register /daily_extra and localize its responses
+
+Files:
+
+- Modify: src/bot/cogs/slash_commands_cog.py
+- Modify: src/bot/utils/ui_constants.py
+- Modify: src/bot/i18n/locales/zh-TW.json
+- Modify: src/bot/i18n/locales/en-US.json
+- Modify: src/bot/i18n/locales/zh-CN.json
+- Modify: tests/test_daily_extra_command.py
+
+Why:
+
+This is the requested public entry point and must compose the approved API/payload/UI contracts while keeping initial visibility separate from detail visibility.
+
+Change Necessity:
+
+No existing command accepts additional daily sources. The minimum boundary is one command callback plus labels and locale keys; the interaction handler remains unchanged.
+
+Impact / Compatibility:
+
+The command is additive. /daily and /daily_cn signatures and behavior do not change. public controls only the initial response.
+
+Verification:
+
+    .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+      tests/test_daily_extra_command.py tests/test_slash_problem_command.py
+
+- [ ] 3.1 Add command, visibility, rendering, validation, and error tests.
+
+  Extend imports in tests/test_daily_extra_command.py:
+
+        import json
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, sentinel
+
+        import pytest
+        from discord.ext import commands
+
+        from bot.api_client import (
+            ApiError,
+            ApiNetworkError,
+            ApiProcessingError,
+            ApiRateLimitError,
+        )
+        from bot.cogs import slash_commands_cog as slash_commands_module
+        from bot.cogs.slash_commands_cog import SlashCommandsCog
+
+  Add these helpers:
+
+        def _make_bot():
+            bot = MagicMock(spec=commands.Bot)
+            bot.api = AsyncMock()
+            bot.llm = MagicMock()
+            bot.llm_pro = MagicMock()
+            bot.config = SimpleNamespace(default_locale="zh-TW")
+            bot.i18n = MagicMock()
+            bot.i18n.resolve_locale = MagicMock(return_value="zh-TW")
+            bot.i18n.t = MagicMock(
+                side_effect=lambda key, locale, **kwargs: key.format(**kwargs)
+            )
+            return bot
+
+
+        def _make_interaction():
+            interaction = AsyncMock(spec=discord.Interaction)
+            interaction.response = AsyncMock()
+            interaction.response.defer = AsyncMock()
+            interaction.followup = AsyncMock()
+            interaction.followup.send = AsyncMock()
+            interaction.user = MagicMock(name="tester", display_name="tester")
+            interaction.user.name = "tester"
+            interaction.guild = MagicMock(id=123)
+            interaction.guild_locale = None
+            interaction.locale = discord.Locale.taiwan_chinese
+            return interaction
+
+
+        def _payload(source: str, problems: list[dict]) -> dict:
+            return {
+                "challenge_info": problems[0],
+                "problems": problems,
+                "history_problems": [],
+                "resolved_date": "2026-06-02",
+                "daily_source": source,
+            }
+
+  Add these tests:
+
+        def test_daily_extra_source_choices_are_exact():
+            source_parameter = next(
+                parameter
+                for parameter in SlashCommandsCog.daily_extra_command.parameters
+                if parameter.name == "source"
+            )
+
+            assert [(choice.name, choice.value) for choice in source_parameter.choices] == [
+                ("Sheep", "sheep"),
+                ("0x3f", "0x3f"),
+            ]
+
+
+        @pytest.mark.asyncio
+        @pytest.mark.parametrize(
+            ("source", "date", "public"),
+            [
+                ("sheep", None, False),
+                ("0x3f", "2026-06-02", True),
+            ],
+        )
+        async def test_daily_extra_single_problem_uses_source_payload_and_visibility(
+            monkeypatch,
+            source,
+            date,
+            public,
+        ):
+            bot = _make_bot()
+            cog = SlashCommandsCog(bot)
+            interaction = _make_interaction()
+            problem = _problem("100A")
+            get_payload = AsyncMock(return_value=_payload(source, [problem]))
+            create_embed = AsyncMock(return_value=sentinel.embed)
+            create_view = AsyncMock(return_value=sentinel.view)
+            monkeypatch.setattr(slash_commands_module, "get_daily_payload", get_payload)
+            monkeypatch.setattr(slash_commands_module, "create_problem_embed", create_embed)
+            monkeypatch.setattr(slash_commands_module, "create_problem_view", create_view)
+
+            await cog.daily_extra_command.callback(
+                cog,
+                interaction,
+                source=source,
+                date=date,
+                public=public,
+            )
+
+            interaction.response.defer.assert_awaited_once_with(ephemeral=not public)
+            get_payload.assert_awaited_once_with(
+                bot,
+                date_str=date,
+                source=source,
+            )
+            interaction.followup.send.assert_awaited_once_with(
+                embed=sentinel.embed,
+                view=sentinel.view,
+                ephemeral=not public,
+            )
+
+
+        @pytest.mark.asyncio
+        async def test_daily_extra_multiple_problems_uses_ordered_overview(monkeypatch):
+            bot = _make_bot()
+            cog = SlashCommandsCog(bot)
+            interaction = _make_interaction()
+            problems = [_problem("100A"), _problem("200B")]
+            monkeypatch.setattr(
+                slash_commands_module,
+                "get_daily_payload",
+                AsyncMock(return_value=_payload("sheep", problems)),
+            )
+            overview_embed = MagicMock(return_value=sentinel.embed)
+            overview_view = MagicMock(return_value=sentinel.view)
+            monkeypatch.setattr(
+                slash_commands_module,
+                "create_problems_overview_embed",
+                overview_embed,
+            )
+            monkeypatch.setattr(
+                slash_commands_module,
+                "create_problems_overview_view",
+                overview_view,
+            )
+
+            await cog.daily_extra_command.callback(
+                cog,
+                interaction,
+                source="sheep",
+                date="2026-06-02",
+                public=True,
+            )
+
+            assert overview_embed.call_args.args[0] == problems
+            assert overview_view.call_args.args[0] == problems
+            interaction.followup.send.assert_awaited_once_with(
+                embed=sentinel.embed,
+                view=sentinel.view,
+                ephemeral=False,
+            )
+
+
+        @pytest.mark.asyncio
+        async def test_daily_extra_rejects_invalid_date_before_api(monkeypatch):
+            bot = _make_bot()
+            cog = SlashCommandsCog(bot)
+            interaction = _make_interaction()
+            get_payload = AsyncMock()
+            monkeypatch.setattr(slash_commands_module, "get_daily_payload", get_payload)
+
+            await cog.daily_extra_command.callback(
+                cog,
+                interaction,
+                source="sheep",
+                date="2026/06/02",
+                public=False,
+            )
+
+            get_payload.assert_not_awaited()
+            interaction.followup.send.assert_awaited_once_with(
+                "errors.validation.date_format",
+                ephemeral=True,
+            )
+
+
+        @pytest.mark.asyncio
+        async def test_daily_extra_reports_not_found(monkeypatch):
+            bot = _make_bot()
+            cog = SlashCommandsCog(bot)
+            interaction = _make_interaction()
+            monkeypatch.setattr(
+                slash_commands_module,
+                "get_daily_payload",
+                AsyncMock(return_value=None),
+            )
+
+            await cog.daily_extra_command.callback(
+                cog,
+                interaction,
+                source="0x3f",
+                date="2026-06-02",
+                public=False,
+            )
+
+            bot.i18n.t.assert_any_call(
+                "errors.validation.daily_extra_not_found",
+                "zh-TW",
+                source_label="0x3f",
+                date="2026-06-02",
+            )
+            assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+        @pytest.mark.asyncio
+        async def test_daily_extra_rejects_unsafe_multi_problem_payload(monkeypatch):
+            bot = _make_bot()
+            cog = SlashCommandsCog(bot)
+            interaction = _make_interaction()
+            problems = [_problem("100A"), _problem("bad|id")]
+            monkeypatch.setattr(
+                slash_commands_module,
+                "get_daily_payload",
+                AsyncMock(return_value=_payload("sheep", problems)),
+            )
+            monkeypatch.setattr(
+                slash_commands_module,
+                "create_problems_overview_view",
+                MagicMock(return_value=None),
+            )
+
+            await cog.daily_extra_command.callback(
+                cog,
+                interaction,
+                source="sheep",
+                date="2026-06-02",
+                public=False,
+            )
+
+            interaction.followup.send.assert_awaited_once_with(
+                "errors.validation.daily_extra_unsafe_payload",
+                ephemeral=True,
+            )
+
+
+        @pytest.mark.asyncio
+        @pytest.mark.parametrize(
+            ("exception", "error_kind"),
+            [
+                (ApiProcessingError("processing"), "processing"),
+                (ApiNetworkError("network"), "network"),
+                (ApiRateLimitError(5), "rate_limit"),
+                (ApiError(500, "failed"), "generic"),
+            ],
+        )
+        async def test_daily_extra_maps_api_errors(monkeypatch, exception, error_kind):
+            bot = _make_bot()
+            cog = SlashCommandsCog(bot)
+            interaction = _make_interaction()
+            monkeypatch.setattr(
+                slash_commands_module,
+                "get_daily_payload",
+                AsyncMock(side_effect=exception),
+            )
+            send_error = AsyncMock()
+            monkeypatch.setattr(slash_commands_module, "send_api_error", send_error)
+
+            await cog.daily_extra_command.callback(
+                cog,
+                interaction,
+                source="sheep",
+                date=None,
+                public=False,
+            )
+
+            send_error.assert_awaited_once_with(
+                interaction,
+                error_kind,
+                bot,
+                ephemeral=True,
+            )
+
+- [ ] 3.2 Verify RED.
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q tests/test_daily_extra_command.py
+
+  Expected: command lookup and callback tests fail because /daily_extra is not registered; locale and label assertions fail because keys are absent.
+
+- [ ] 3.3 Implement labels, locale keys, and the command.
+
+  Add to SOURCE_LABELS in src/bot/utils/ui_constants.py:
+
+        "sheep": "Sheep",
+        "0x3f": "0x3f",
+
+  Add these keys to all three locale files, translating values exactly:
+
+  | Key | zh-TW | en-US | zh-CN |
+  | --- | --- | --- | --- |
+  | commands.daily_extra.description | 查詢 Sheep 或 0x3f 每日題目 | Query Sheep or 0x3f daily problems | 查询 Sheep 或 0x3f 每日题目 |
+  | commands.daily_extra.source | 每日題目來源 | Daily problem source | 每日题目来源 |
+  | commands.daily_extra.date | 指定日期（YYYY-MM-DD），不填則為今天 | Date (YYYY-MM-DD), defaults to today | 指定日期（YYYY-MM-DD），不填则为今天 |
+  | commands.daily_extra.public | 是否公開顯示初始回覆（題目詳情仍為私密） | Show the initial response publicly (details remain private) | 是否公开显示初始回复（题目详情仍为私密） |
+  | errors.validation.daily_extra_not_found | 找不到 {source_label} 在 {date} 的每日題目。 | No {source_label} daily problems were found for {date}. | 找不到 {source_label} 在 {date} 的每日题目。 |
+  | errors.validation.daily_extra_unsafe_payload | 每日題目數量或題號無法安全顯示，請稍後再試。 | The daily problem set cannot be displayed safely. Please try again later. | 每日题目数量或题号无法安全显示，请稍后再试。 |
+  | ui.embed.daily_extra_title | 📅 {source_label} Daily（{date}，共 {count} 題） | 📅 {source_label} Daily ({date}, {count} problems) | 📅 {source_label} Daily（{date}，共 {count} 题） |
+  | ui.embed.daily_extra_footer | 📅 {source_label} Daily \u007c {date} | 📅 {source_label} Daily \u007c {date} | 📅 {source_label} Daily \u007c {date} |
+
+  Add this command after daily_cn_command() in src/bot/cogs/slash_commands_cog.py:
+
+        @app_commands.command(
+            name="daily_extra",
+            description=app_commands.locale_str("daily_extra.description"),
+        )
+        @app_commands.describe(
+            source=app_commands.locale_str("daily_extra.source"),
+            date=app_commands.locale_str("daily_extra.date"),
+            public=app_commands.locale_str("daily_extra.public"),
+        )
+        @app_commands.choices(
+            source=[
+                app_commands.Choice(name="Sheep", value="sheep"),
+                app_commands.Choice(name="0x3f", value="0x3f"),
+            ]
+        )
+        async def daily_extra_command(
+            self,
+            interaction: discord.Interaction,
+            source: str,
+            date: str = None,
+            public: bool = False,
+        ):
+            await interaction.response.defer(ephemeral=not public)
+            locale = _get_locale(self.bot, interaction)
+            i18n = self.bot.i18n
+
+            if date and not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+                await interaction.followup.send(
+                    i18n.t("errors.validation.date_format", locale),
+                    ephemeral=not public,
+                )
+                return
+
+            try:
+                payload = await get_daily_payload(
+                    self.bot,
+                    date_str=date,
+                    source=source,
+                )
+                source_label = get_source_label(source)
+                requested_date = date or (
+                    payload.get("resolved_date")
+                    if payload
+                    else i18n.t("ui.embed.today", locale)
+                )
+                if not payload:
+                    await interaction.followup.send(
+                        i18n.t(
+                            "errors.validation.daily_extra_not_found",
+                            locale,
+                            source_label=source_label,
+                            date=requested_date,
+                        ),
+                        ephemeral=not public,
+                    )
+                    return
+
+                problems = payload["problems"]
+                resolved_date = payload["resolved_date"]
+                footer_text = i18n.t(
+                    "ui.embed.daily_extra_footer",
+                    locale,
+                    source_label=source_label,
+                    date=resolved_date,
+                )
+
+                if len(problems) == 1:
+                    problem = problems[0]
+                    embed = await create_problem_embed(
+                        problem_info=problem,
+                        bot=self.bot,
+                        domain="com",
+                        is_daily=False,
+                        date_str=resolved_date,
+                        locale=locale,
+                        footer_text=footer_text,
+                    )
+                    view = await create_problem_view(
+                        problem_info=problem,
+                        bot=self.bot,
+                        domain="com",
+                        locale=locale,
+                    )
+                else:
+                    view = create_problems_overview_view(problems, "com")
+                    if view is None:
+                        await interaction.followup.send(
+                            i18n.t(
+                                "errors.validation.daily_extra_unsafe_payload",
+                                locale,
+                            ),
+                            ephemeral=not public,
+                        )
+                        return
+                    embed = create_problems_overview_embed(
+                        problems,
+                        "com",
+                        title=i18n.t(
+                            "ui.embed.daily_extra_title",
+                            locale,
+                            source_label=source_label,
+                            date=resolved_date,
+                            count=len(problems),
+                        ),
+                        source_label=source_label,
+                        footer_icon_url=get_source_logo_url(source),
+                        footer_text=footer_text,
+                        bot=self.bot,
+                        locale=locale,
+                    )
+
+                await interaction.followup.send(
+                    embed=embed,
+                    view=view,
+                    ephemeral=not public,
+                )
+                self.logger.info(
+                    "Sent %s daily challenge for %s with %d problems to user %s",
+                    source,
+                    resolved_date,
+                    len(problems),
+                    interaction.user.name,
+                )
+            except ApiProcessingError:
+                await send_api_error(
+                    interaction,
+                    "processing",
+                    self.bot,
+                    ephemeral=not public,
+                )
+            except ApiNetworkError:
+                await send_api_error(
+                    interaction,
+                    "network",
+                    self.bot,
+                    ephemeral=not public,
+                )
+            except ApiRateLimitError:
+                await send_api_error(
+                    interaction,
+                    "rate_limit",
+                    self.bot,
+                    ephemeral=not public,
+                )
+            except ApiError as error:
+                self.logger.error("API error in daily_extra command: %s", error)
+                await send_api_error(
+                    interaction,
+                    "generic",
+                    self.bot,
+                    ephemeral=not public,
+                )
+            except Exception as error:
+                self.logger.error(
+                    "Unexpected error in daily_extra command: %s",
+                    error,
+                    exc_info=True,
+                )
+                await send_api_error(
+                    interaction,
+                    "generic",
+                    self.bot,
+                    ephemeral=not public,
+                )
+
+  Include this localized fallback key in the same locale edit:
+
+  | Key | zh-TW | en-US | zh-CN |
+  | --- | --- | --- | --- |
+  | ui.embed.today | 今天 | today | 今天 |
+
+- [ ] 3.4 Verify GREEN, locale parity, and existing commands.
+
+  Add a locale parity test to tests/test_daily_extra_command.py:
+
+        def test_daily_extra_locale_keys_have_parity():
+            locale_dir = Path("src/bot/i18n/locales")
+            documents = {
+                path.stem: json.loads(path.read_text(encoding="utf-8"))
+                for path in locale_dir.glob("*.json")
+            }
+
+            def flatten(value, prefix=""):
+                keys = set()
+                for key, child in value.items():
+                    path = f"{prefix}.{key}" if prefix else key
+                    keys.add(path)
+                    if isinstance(child, dict):
+                        keys.update(flatten(child, path))
+                return keys
+
+            expected = flatten(documents["zh-TW"])
+            assert flatten(documents["en-US"]) == expected
+            assert flatten(documents["zh-CN"]) == expected
+
+  Run:
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+          tests/test_daily_extra_command.py tests/test_slash_problem_command.py
+        uv run --extra dev ruff check \
+          src/bot/cogs/slash_commands_cog.py \
+          src/bot/utils/ui_constants.py \
+          tests/test_daily_extra_command.py
+
+  Expected: command scenarios pass, locale key sets match, and existing /daily and /daily_cn tests remain green.
+
+- [ ] 3.5 Commit the command and localization slice.
+
+        git add \
+          src/bot/cogs/slash_commands_cog.py \
+          src/bot/utils/ui_constants.py \
+          src/bot/i18n/locales/zh-TW.json \
+          src/bot/i18n/locales/en-US.json \
+          src/bot/i18n/locales/zh-CN.json \
+          tests/test_daily_extra_command.py
+        git commit -m "✨ feat(daily): add manual extra sources"
+
+## Task 4: Lock privacy, document usage, and run completion verification
+
+Files:
+
+- Modify: tests/test_interaction_handler.py
+- Modify: README.md
+- Verify: all OpenSpec and source/test artifacts
+
+Why:
+
+The existing handler already sends view details ephemerally, but this is a user-critical concurrency guarantee and needs explicit preservation evidence. The public command also needs user-facing usage documentation.
+
+Change Necessity:
+
+No interaction source edit is required. A characterization assertion and README update are sufficient for this slice.
+
+Impact / Compatibility:
+
+No runtime behavior changes in InteractionHandlerCog. Documentation states that public controls the initial response only.
+
+Verification:
+
+Use the full commands in the plan Verification section.
+
+- [ ] 4.1 Add the privacy characterization assertions.
+
+  In TestInteractionHandler.test_problem_view_button_for_luogu_returns_full_problem_card(), retain all existing assertions and add:
+
+        assert kwargs["ephemeral"] is True
+        mock_interaction.edit_original_response.assert_not_awaited()
+
+  This test should already pass before source changes; it is a compatibility lock, not a new failing behavior test.
+
+  Also extend the unittest.mock import with sentinel and add this concurrent characterization test to TestInteractionHandler:
+
+        @pytest.mark.asyncio
+        async def test_problem_view_clicks_are_private_and_independent_per_user(
+            self,
+            cog,
+            mock_bot,
+            monkeypatch,
+        ):
+            def make_click(user_id: int, problem_id: str):
+                interaction = AsyncMock(spec=discord.Interaction)
+                interaction.type = discord.InteractionType.component
+                interaction.data = {
+                    "custom_id": f"problem|codeforces|{problem_id}|view"
+                }
+                interaction.user = MagicMock(id=user_id, name=f"user-{user_id}")
+                interaction.response = AsyncMock()
+                interaction.response.defer = AsyncMock()
+                interaction.followup = AsyncMock()
+                interaction.followup.send = AsyncMock()
+                interaction.guild = MagicMock(id=987654321)
+                interaction.guild_locale = None
+                interaction.locale = discord.Locale.taiwan_chinese
+                return interaction
+
+            first = make_click(1, "100A")
+            second = make_click(2, "200B")
+            mock_bot.api.get_problem.side_effect = [
+                {
+                    "id": "100A",
+                    "source": "codeforces",
+                    "title": "First",
+                    "link": "https://example.com/100A",
+                },
+                {
+                    "id": "200B",
+                    "source": "codeforces",
+                    "title": "Second",
+                    "link": "https://example.com/200B",
+                },
+            ]
+            monkeypatch.setattr(
+                interaction_handler_module,
+                "create_problem_embed",
+                AsyncMock(side_effect=[sentinel.first_embed, sentinel.second_embed]),
+            )
+            monkeypatch.setattr(
+                interaction_handler_module,
+                "create_problem_view",
+                AsyncMock(side_effect=[sentinel.first_view, sentinel.second_view]),
+            )
+
+            await asyncio.gather(
+                cog.on_interaction(first),
+                cog.on_interaction(second),
+            )
+
+            first.response.defer.assert_awaited_once_with(ephemeral=True)
+            second.response.defer.assert_awaited_once_with(ephemeral=True)
+            assert first.followup.send.await_args.kwargs["ephemeral"] is True
+            assert second.followup.send.await_args.kwargs["ephemeral"] is True
+            first.edit_original_response.assert_not_awaited()
+            second.edit_original_response.assert_not_awaited()
+
+- [ ] 4.2 Run the privacy test against the current unchanged handler.
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+          tests/test_interaction_handler.py::TestInteractionHandler::test_problem_view_button_for_luogu_returns_full_problem_card
+
+  Expected: pass without modifying interaction_handler_cog.py.
+
+- [ ] 4.3 Update README usage and examples.
+
+  Add this row after /daily_cn:
+
+        | /daily_extra <source> [date] [public] | Query Sheep or 0x3f daily problems<br>• source: sheep or 0x3f<br>• Optional: YYYY-MM-DD date<br>• Optional: public shows the initial response publicly<br>• Multi-problem results open as an overview; selected details are always private | None |
+
+  Add these examples to the Daily Challenge Commands block:
+
+        /daily_extra source:sheep
+        /daily_extra source:0x3f date:2026-06-09
+        /daily_extra source:sheep public:true
+
+  Add one sentence below Multi-Problem Features:
+
+        /daily_extra also uses overview mode when a daily source returns multiple problems. Clicking a problem ID opens a private full-problem card for the clicking user, even when the overview is public.
+
+- [ ] 4.4 Run full verification and architecture review.
+
+        .venv/bin/pytest -o addopts='' -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache -q \
+          tests/test_daily_payload_reuse.py \
+          tests/test_daily_extra_command.py \
+          tests/test_slash_problem_command.py \
+          tests/test_interaction_handler.py \
+          tests/test_history_dates.py \
+          tests/test_schedule_manager_cog.py
+        uv run --extra dev ruff check .
+        uv run --extra dev pytest -o cache_dir=/tmp/leetcode-daily-discord-bot-pytest-cache
+        openspec validate add-daily-extra-command --strict --no-interactive
+        python3 /home/usaya/.codex/aegis/scripts/aegis-workspace.py check --root .
+        git diff --check
+
+  Architecture review checklist:
+
+  - No scheduler, DB, or config files changed.
+  - No new custom-id prefix or interaction state exists.
+  - get_daily() and v0.4 tests remain unchanged and green.
+  - target cache keys are namespaced.
+  - extra-source history calls are absent.
+  - every accepted overview is complete and ordered.
+  - selected detail responses remain ephemeral.
+  - all locale keys have parity.
+
+- [ ] 4.5 Commit documentation and compatibility evidence.
+
+        git add README.md tests/test_interaction_handler.py
+        git commit -m "📝 docs(daily): document extra source queries"
+
+## Test Case Matrix
+
+| Contract | Test evidence |
+| --- | --- |
+| Source-only API request | test_get_daily_by_source_sends_source_without_domain |
+| Full ordered envelope | test_extra_daily_payload_preserves_order_and_skips_history |
+| Cache target isolation | test_daily_payload_cache_isolated_by_target |
+| In-flight reuse | test_extra_daily_payload_coalesces_identical_in_flight_requests |
+| Exact source choices | test_daily_extra_source_choices_are_exact |
+| Current and dated requests | test_daily_extra_single_problem_uses_source_payload_and_visibility |
+| Default private / explicit public | same parameterized command test |
+| Single full card | same command test with mocked card/view builders |
+| Multi ordered overview | test_daily_extra_multiple_problems_uses_ordered_overview |
+| Invalid date avoids API | test_daily_extra_rejects_invalid_date_before_api |
+| 404 / empty payload | test_daily_extra_reports_not_found |
+| 202/network/rate/API errors | test_daily_extra_maps_api_errors |
+| Exact 25-button layout | test_daily_overview_view_preserves_exact_25_problem_order |
+| More than 25 rejected | test_daily_overview_view_rejects_more_than_25_problems |
+| Unsafe custom-id segment rejected | test_daily_overview_view_rejects_unsafe_routing_fields |
+| Localized source/date footer | test_daily_overview_embed_accepts_daily_footer_override |
+| Private selected detail | existing interaction view test plus ephemeral assertion |
+| Concurrent click isolation | test_problem_view_clicks_are_private_and_independent_per_user |
+| Locale parity | test_daily_extra_locale_keys_have_parity |
+| Existing LeetCode and schedule regression | test_daily_payload_reuse.py, test_slash_problem_command.py, test_history_dates.py, test_schedule_manager_cog.py |
+
+## Risks
+
+- The planned localized "today" fallback must not remain an English literal in non-English locales.
+- Changing create_problems_overview_view() to Optional requires checking every caller; current callers are /problem and the new /daily_extra.
+- A partial or malformed upstream envelope must fail closed; do not filter invalid items and render a subset.
+- Full tests instantiate file logging. Run inside the writable worktree and keep pytest cache in /tmp.
+- If the full suite exposes unrelated baseline failures, compare against ba8cc10 before attributing them to this change; do not waive failures in touched paths.
+
+## Retirement
+
+- No production owner, legacy path, or compatibility normalization is retired.
+- No fallback or adapter is added.
+- The new API method and command should be removed together if oj-api-rs removes additional daily source support.
+- The v0.4 LeetCode normalization remains only because existing configured backends may still use it; this change does not extend that compatibility path.
+
+## Completion Evidence Required
+
+- OpenSpec status shows 4/4 artifacts and strict validation succeeds.
+- Focused and full pytest commands succeed.
+- Ruff and git diff checks succeed.
+- Locale key parity succeeds.
+- Git diff confirms no scheduler, DB, config, or interaction-router source changes.
+- Architecture review confirms one API owner, one cache owner, one UI safety owner, and one interaction protocol.

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/10-intent.md
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/10-intent.md
@@ -1,0 +1,74 @@
+# Implement /daily_extra command - Intent
+
+## TaskIntentDraft
+
+- Requested outcome: Implement the approved manual /daily_extra command for sheep and 0x3f with ordered multi-problem overview and private selected details
+- Goal: Complete all four implementation-plan slices and prove the OpenSpec acceptance boundary
+- Success evidence:
+- Focused and full pytest pass; Ruff, OpenSpec strict validation, Aegis workspace check, and diff check pass
+- Stop condition: done when every plan/OpenSpec task is implemented and verified; otherwise report blocked, needs-verification, or scope-exceeded
+- Non-goals:
+- No scheduler support for extra sources
+- No database or configuration changes
+- No pagination, message editing, or new interaction protocol
+- Scope: API client, daily payload cache, overview UI safety, slash command, i18n, privacy regression tests, README, and verification
+- Change kinds:
+- feature
+- Risk hints:
+- Cross-module API/cache/UI contract; preserve v0.4 LeetCode and scheduled delivery behavior
+
+## BaselineReadSetHint
+
+- openspec/changes/add-daily-extra-command
+- docs/aegis/plans/2026-07-16-add-daily-extra-command.md
+- /home/usaya/workspace/github/oj-api-rs/openspec/specs/daily-challenge/spec.md@4536487
+
+## BaselineUsageDraft
+
+- Required baseline refs:
+- openspec/changes/add-daily-extra-command
+- docs/aegis/plans/2026-07-16-add-daily-extra-command.md
+- /home/usaya/workspace/github/oj-api-rs/openspec/specs/daily-challenge/spec.md@4536487
+- Acknowledged before plan:
+- none
+- Cited in plan:
+- none
+- Missing refs:
+- openspec/changes/add-daily-extra-command
+- docs/aegis/plans/2026-07-16-add-daily-extra-command.md
+- /home/usaya/workspace/github/oj-api-rs/openspec/specs/daily-challenge/spec.md@4536487
+- Advisory decision: needs-baseline-readback
+
+## ImpactStatementDraft
+
+- Compatibility boundary: Keep get_daily(domain,date), v0.4 normalization, /daily, /daily_cn, scheduling, DB, config, and problem custom ids stable
+- Affected layers:
+- API client
+- daily payload cache
+- Discord command/UI
+- Owners:
+- Existing OjApiClient, get_daily_payload, ui_helpers, SlashCommandsCog, and InteractionHandlerCog owners
+- Invariants:
+- Cache identity is request-target namespace plus date; selected details are always ephemeral
+- Non-goals:
+- No scheduler support for extra sources
+- No database or configuration changes
+- No pagination, message editing, or new interaction protocol
+
+These records are Method Pack drafts / hints, not authoritative runtime decisions.
+
+## BaselineUsageDraft
+
+- Required baseline refs:
+- openspec/changes/add-daily-extra-command
+- openspec/specs/interaction-handler/spec.md
+- openspec/specs/discord-ui/spec.md
+- Delivered context refs:
+- existing api_client ui_helpers slash_commands interaction_handler and locale owners
+- Acknowledged before plan:
+- docs/aegis/plans/2026-07-16-add-daily-extra-command.md
+- Cited in plan:
+- upstream oj-api-rs dev daily source contract
+- Missing refs:
+- none
+- Advisory decision: continue

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/20-checkpoint.md
@@ -1,0 +1,60 @@
+# Implement /daily_extra command - Checkpoint
+
+- Task ID: 2026-07-16-implement-daily-extra-command
+- Current todo: Task 1: source-only API method and target-aware daily payload
+- Active slice: API/payload tests and implementation
+- Blocked on: none
+- Next step: Run focused clean baseline tests, then write Task 1 RED tests
+
+## Checkpoint Update
+
+- Current todo: Task 2 overview button safety and footer support
+- Active slice: Task 2
+- Completed todos:
+- Task 1 API source method and target-aware daily payload implemented
+- Evidence refs:
+- Task 1 focused regression: 29 passed
+- Blocked on: none
+- Next step: Add failing overview tests, then implement all-or-nothing button validation
+
+## Checkpoint Update
+
+- Current todo: Task 3 slash command and localization
+- Active slice: Task 3
+- Completed todos:
+- Task 2 all-or-nothing overview buttons and footer override implemented
+- Evidence refs:
+- Task 2 focused regression: 40 passed
+- Blocked on: none
+- Next step: Add command acceptance tests, then implement /daily_extra and locale keys
+
+## Checkpoint Update
+
+- Current todo: Task 4 privacy characterization, docs, and completion verification
+- Active slice: Task 4
+- Completed todos:
+- Task 3 manual /daily_extra command and three-locale strings implemented
+- Evidence refs:
+- Task 3 tests: 31 passed; focused Ruff passed
+- Blocked on: none
+- Next step: Lock private independent detail clicks, update README, then run full verification
+
+## DriftCheckDraft
+
+- Scope status: manual daily_extra only; no scheduler DB config or new interaction route
+- Compatibility status: existing daily daily_cn schedule and v0.4 compatibility focused regressions pass
+- Retirement status: no owner or path retired; unified problem view route reused
+- New risk signals:
+- three pre-existing path assertions fail because worktree runtime assets are symlinked to main checkout
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: No implementation work remains; preserve worktree for user handoff
+- Active slice: Closeout
+- Completed todos:
+- Tasks 1-4 and all approved implementation scope completed
+- Evidence refs:
+- 86 focused tests pass; Ruff and OpenSpec pass; full suite 229 pass with 3 worktree symlink baseline failures
+- Blocked on: none
+- Next step: User may request commit or PR after reviewing the documented baseline-only test failures

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/90-evidence.md
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/90-evidence.md
@@ -1,0 +1,51 @@
+# Implement /daily_extra command - Evidence
+
+No evidence has been recorded yet.
+
+## EvidenceBundleDraft
+
+- Artifact key: task1-focused-tests
+- Type: test
+- Source: pytest test_daily_payload_reuse.py test_history_dates.py test_schedule_manager_cog.py
+- Summary: 29 tests passed with sandbox log directory redirected to /tmp
+- Verifier: codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task2-focused-tests
+- Type: test
+- Source: pytest daily_extra similar_results similar_cog slash_problem
+- Summary: 40 tests passed, including 25-button order and unsafe payload rejection
+- Verifier: codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task3-command-tests
+- Type: test
+- Source: pytest daily_extra slash_problem and focused ruff
+- Summary: 31 tests passed; command choices, visibility, API errors, and locale parity verified; Ruff clean
+- Verifier: codex
+
+## EvidenceBundleDraft
+
+- Artifact key: final-focused-tests
+- Type: test
+- Source: pytest focused API payload UI slash interaction history schedule suite
+- Summary: 86 passed in 4.50s
+- Verifier: codex
+
+## EvidenceBundleDraft
+
+- Artifact key: final-static-spec-checks
+- Type: verification
+- Source: ruff, openspec strict, git diff check
+- Summary: Ruff clean; OpenSpec valid; CRLF-aware diff check clean
+- Verifier: codex
+
+## EvidenceBundleDraft
+
+- Artifact key: full-suite-baseline
+- Type: test
+- Source: pytest all repository tests
+- Summary: 229 passed; 3 existing worktree symlink path assertions failed outside changed files
+- Verifier: codex

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/99-reflection.md
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/99-reflection.md
@@ -1,0 +1,5 @@
+# Implement /daily_extra command - Reflection
+
+Completion reflection has not been recorded yet.
+
+Method Pack output does not grant completion authority.

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/baseline-read-set-hint.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/baseline-read-set-hint.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "candidateDocs": [
+    "openspec/changes/add-daily-extra-command",
+    "docs/aegis/plans/2026-07-16-add-daily-extra-command.md",
+    "/home/usaya/workspace/github/oj-api-rs/openspec/specs/daily-challenge/spec.md@4536487"
+  ],
+  "whyRelevant": "These refs define accepted behavior, owner boundaries, upstream query shape, and verification obligations",
+  "missingAuthority": []
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/baseline-usage-draft.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/baseline-usage-draft.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-16-implement-daily-extra-command",
+  "requiredBaselineRefs": [
+    "openspec/changes/add-daily-extra-command",
+    "openspec/specs/interaction-handler/spec.md",
+    "openspec/specs/discord-ui/spec.md"
+  ],
+  "deliveredContextRefs": [
+    "existing api_client ui_helpers slash_commands interaction_handler and locale owners"
+  ],
+  "acknowledgedBeforePlanRefs": [
+    "docs/aegis/plans/2026-07-16-add-daily-extra-command.md"
+  ],
+  "citedInPlanRefs": [
+    "upstream oj-api-rs dev daily source contract"
+  ],
+  "missingRefs": [],
+  "decision": "continue"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/drift-check-draft.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/drift-check-draft.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-16-implement-daily-extra-command",
+  "taskIntentRef": "docs/aegis/work/2026-07-16-implement-daily-extra-command/task-intent-draft.json",
+  "baselineRefs": [
+    "openspec/changes/add-daily-extra-command",
+    "docs/aegis/plans/2026-07-16-add-daily-extra-command.md"
+  ],
+  "scopeStatus": "manual daily_extra only; no scheduler DB config or new interaction route",
+  "compatStatus": "existing daily daily_cn schedule and v0.4 compatibility focused regressions pass",
+  "retirementStatus": "no owner or path retired; unified problem view route reused",
+  "newRiskSignals": [
+    "three pre-existing path assertions fail because worktree runtime assets are symlinked to main checkout"
+  ],
+  "decision": "continue"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-focused-tests.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-focused-tests.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "final-focused-tests",
+  "type": "test",
+  "source": "pytest focused API payload UI slash interaction history schedule suite",
+  "summary": "86 passed in 4.50s",
+  "verifier": "codex"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-static-spec-checks.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-static-spec-checks.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "final-static-spec-checks",
+  "type": "verification",
+  "source": "ruff, openspec strict, git diff check",
+  "summary": "Ruff clean; OpenSpec valid; CRLF-aware diff check clean",
+  "verifier": "codex"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-full-suite-baseline.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-full-suite-baseline.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "full-suite-baseline",
+  "type": "test",
+  "source": "pytest all repository tests",
+  "summary": "229 passed; 3 existing worktree symlink path assertions failed outside changed files",
+  "verifier": "codex"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task1-focused-tests.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task1-focused-tests.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "task1-focused-tests",
+  "type": "test",
+  "source": "pytest test_daily_payload_reuse.py test_history_dates.py test_schedule_manager_cog.py",
+  "summary": "29 tests passed with sandbox log directory redirected to /tmp",
+  "verifier": "codex"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task2-focused-tests.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task2-focused-tests.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "task2-focused-tests",
+  "type": "test",
+  "source": "pytest daily_extra similar_results similar_cog slash_problem",
+  "summary": "40 tests passed, including 25-button order and unsafe payload rejection",
+  "verifier": "codex"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task3-command-tests.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task3-command-tests.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "task3-command-tests",
+  "type": "test",
+  "source": "pytest daily_extra slash_problem and focused ruff",
+  "summary": "31 tests passed; command choices, visibility, API errors, and locale parity verified; Ruff clean",
+  "verifier": "codex"
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/gate-input-pack.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/gate-input-pack.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "baselineRefs": [
+    "openspec/changes/add-daily-extra-command",
+    "docs/aegis/plans/2026-07-16-add-daily-extra-command.md"
+  ],
+  "impactStatement": "docs/aegis/work/2026-07-16-implement-daily-extra-command/impact-statement-draft.json",
+  "compatPlan": "Keep get_daily(domain,date), v0.4 normalization, /daily, /daily_cn, scheduling, DB, config, and problem custom ids stable",
+  "retirementPlan": "no owner or path retired; unified problem view route reused",
+  "evidenceBundle": [
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-focused-tests.json",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-static-spec-checks.json",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-full-suite-baseline.json",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task1-focused-tests.json",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task2-focused-tests.json",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task3-command-tests.json"
+  ]
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/impact-statement-draft.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/impact-statement-draft.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "affectedLayers": [
+    "API client",
+    "daily payload cache",
+    "Discord command/UI"
+  ],
+  "owners": [
+    "Existing OjApiClient, get_daily_payload, ui_helpers, SlashCommandsCog, and InteractionHandlerCog owners"
+  ],
+  "invariants": [
+    "Cache identity is request-target namespace plus date; selected details are always ephemeral"
+  ],
+  "compatBoundary": "Keep get_daily(domain,date), v0.4 normalization, /daily, /daily_cn, scheduling, DB, config, and problem custom ids stable",
+  "nonGoals": [
+    "No scheduler support for extra sources",
+    "No database or configuration changes",
+    "No pagination, message editing, or new interaction protocol"
+  ]
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/proof-bundle.md
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/proof-bundle.md
@@ -1,0 +1,34 @@
+# Proof Bundle - 2026-07-16-implement-daily-extra-command
+
+## Method Pack Boundary
+
+This proof bundle is an advisory Aegis Method Pack record. It does not determine evidence sufficiency, produce authoritative `GateDecision`, or grant `completion authority`.
+
+## Task Intent
+
+- Requested outcome: Implement the approved manual /daily_extra command for sheep and 0x3f with ordered multi-problem overview and private selected details
+- Scope: API client, daily payload cache, overview UI safety, slash command, i18n, privacy regression tests, README, and verification
+
+## Impact
+
+- Compatibility boundary: Keep get_daily(domain,date), v0.4 normalization, /daily, /daily_cn, scheduling, DB, config, and problem custom ids stable
+- Non-goals:
+- No scheduler support for extra sources
+- No database or configuration changes
+- No pagination, message editing, or new interaction protocol
+
+## Evidence Bundle Refs
+
+- docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-focused-tests.json
+- docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-final-static-spec-checks.json
+- docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-full-suite-baseline.json
+- docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task1-focused-tests.json
+- docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task2-focused-tests.json
+- docs/aegis/work/2026-07-16-implement-daily-extra-command/evidence-bundle-draft-task3-command-tests.json
+
+## Drift Check
+
+- Scope status: manual daily_extra only; no scheduler DB config or new interaction route
+- Compatibility status: existing daily daily_cn schedule and v0.4 compatibility focused regressions pass
+- Retirement status: no owner or path retired; unified problem view route reused
+- Advisory decision: continue

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/resume-state-hint.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/resume-state-hint.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-16-implement-daily-extra-command",
+  "lastCheckpointRef": "docs/aegis/work/2026-07-16-implement-daily-extra-command/todo-checkpoint-draft.json",
+  "resumeInstruction": "Review git diff and verification evidence; do not rerun implementation slices",
+  "knownPartialWork": [
+    "Tasks 1-4 and all approved implementation scope completed"
+  ],
+  "mustReadBeforeContinuing": [
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/10-intent.md",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/20-checkpoint.md",
+    "docs/aegis/work/2026-07-16-implement-daily-extra-command/todo-checkpoint-draft.json"
+  ],
+  "unsafeToAssume": []
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/task-intent-draft.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/task-intent-draft.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "requestedOutcome": "Implement the approved manual /daily_extra command for sheep and 0x3f with ordered multi-problem overview and private selected details",
+  "goal": "Complete all four implementation-plan slices and prove the OpenSpec acceptance boundary",
+  "successEvidence": [
+    "Focused and full pytest pass; Ruff, OpenSpec strict validation, Aegis workspace check, and diff check pass"
+  ],
+  "stopCondition": "done when every plan/OpenSpec task is implemented and verified; otherwise report blocked, needs-verification, or scope-exceeded",
+  "nonGoals": [
+    "No scheduler support for extra sources",
+    "No database or configuration changes",
+    "No pagination, message editing, or new interaction protocol"
+  ],
+  "scope": "API client, daily payload cache, overview UI safety, slash command, i18n, privacy regression tests, README, and verification",
+  "changeKinds": [
+    "feature"
+  ],
+  "riskHints": [
+    "Cross-module API/cache/UI contract; preserve v0.4 LeetCode and scheduled delivery behavior"
+  ]
+}

--- a/docs/aegis/work/2026-07-16-implement-daily-extra-command/todo-checkpoint-draft.json
+++ b/docs/aegis/work/2026-07-16-implement-daily-extra-command/todo-checkpoint-draft.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-16-implement-daily-extra-command",
+  "currentTodo": "No implementation work remains; preserve worktree for user handoff",
+  "completedTodos": [
+    "Tasks 1-4 and all approved implementation scope completed"
+  ],
+  "activeSlice": "Closeout",
+  "evidenceRefs": [
+    "86 focused tests pass; Ruff and OpenSpec pass; full suite 229 pass with 3 worktree symlink baseline failures"
+  ],
+  "blockedOn": null,
+  "nextStep": "User may request commit or PR after reviewing the documented baseline-only test failures",
+  "updatedAt": "2026-07-16"
+}

--- a/openspec/changes/add-daily-extra-command/.openspec.yaml
+++ b/openspec/changes/add-daily-extra-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/add-daily-extra-command/design.md
+++ b/openspec/changes/add-daily-extra-command/design.md
@@ -47,7 +47,7 @@ Alternative considered: create a separate uncached `get_extra_daily_payload()` p
 
 For one problem, `/daily_extra` uses the existing full problem embed/view builders with an additional-source daily footer. For multiple problems, it uses the existing overview embed/view builders, preserving upstream order and using each problem's own `source` and `id` in `problem|{source}|{problem_id}|view`.
 
-The overview builder receives localized daily-specific title/footer text. The generic problem-overview view gains an all-or-nothing safety decision shared with existing detail-button validation: every displayed item must have safe routing segments, every custom id must fit Discord limits, and the complete result set must fit within 25 buttons. An unsafe payload produces a localized command error and no partial overview.
+The overview builder receives localized daily-specific title/footer text. The generic problem-overview view gains an all-or-nothing safety decision shared with existing detail-button validation: every displayed item must have safe routing segments, every custom id must fit Discord limits, and the complete result set must fit within 25 buttons. Generic `/problem` overviews retain the existing missing-source default of `leetcode`, while `/daily_extra` opts into explicit-source validation and rejects generated overviews that exceed Discord embed field or total-length limits. An unsafe additional-source payload produces a localized command error and no partial overview.
 
 Alternative considered: add two daily-specific toggle buttons or edit the original message in place. That would introduce shared state and allow concurrent users to overwrite the same message.
 

--- a/openspec/changes/add-daily-extra-command/design.md
+++ b/openspec/changes/add-daily-extra-command/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The bot's LeetCode `/daily` and `/daily_cn` flows already consume the normalized oj-api-rs daily envelope, but `get_daily_payload()` collapses that envelope to `problems[0]` and performs LeetCode-specific historical lookups. The current oj-api-rs `dev` contract also accepts `source=sheep` and `source=0x3f`; those records can contain multiple ordered problems and can return `202` while ingestion is running or `404` for unavailable source/date combinations.
+
+The bot already has the interaction primitives needed for a multi-problem response: `create_problems_overview_embed()`, `create_problems_overview_view()`, and the persistent `problem|{source}|{problem_id}|view` route. The `view` handler fetches the selected problem and sends its full card ephemerally. Reusing these owners avoids shared mutable page state and prevents one user's click from replacing another user's view.
+
+The first delivery is intentionally manual-only. Existing LeetCode commands, configured scheduled posts, database state, and guild configuration remain outside this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `/daily_extra source:<sheep|0x3f> [date] [public]` with localized metadata and responses.
+- Preserve every problem and its upstream order from the daily envelope.
+- Render one problem directly and multiple problems as a safe overview.
+- Keep selected problem details private to the clicking user.
+- Keep cache/in-flight reuse collision-free across LeetCode domains and additional sources.
+- Preserve all existing LeetCode daily behavior and oj-api-rs v0.4 LeetCode normalization.
+
+**Non-Goals:**
+
+- Add `sheep` or `0x3f` to scheduled delivery.
+- Add guild configuration, database schema, or persistence for additional sources.
+- Add message-editing pagination, per-user view state, or a daily-specific custom-id protocol.
+- Add client-side source availability calendars; oj-api-rs remains authoritative for first-date and weekday availability.
+- Add more daily sources beyond `sheep` and `0x3f`.
+
+## Decisions
+
+### Keep the additional-source API call separate from the legacy-compatible LeetCode method
+
+Add `OjApiClient.get_daily_by_source(source, date=None)` and share only the internal request/envelope handling needed by both daily methods. Keep `get_daily(domain="com", date=None)` and `_normalize_daily_response()` behavior stable so configured oj-api-rs v0.4 backends continue to support `/daily` and `/daily_cn`.
+
+The additional-source method sends `source` and optional `date` parameters without a `domain` parameter. It does not claim v0.4 support because those sources are available only on the newer upstream contract.
+
+Alternative considered: add a `source` keyword to `get_daily()`. Its default `domain="com"` makes conflict-free parameter construction easy to misuse, and changing the signature weakens the existing compatibility boundary.
+
+### Generalize the existing payload cache around an explicit request target
+
+Extend `get_daily_payload()` with an optional additional-source target while preserving current positional LeetCode callers. Build cache and in-flight keys from an explicit namespace (`domain:com`, `domain:cn`, `source:sheep`, or `source:0x3f`) plus explicit/resolved date. Return the complete `problems` list in the payload while retaining `challenge_info` as the first problem for existing callers.
+
+Only LeetCode domain targets perform historical same-day fan-out. Additional-source targets return an empty `history_problems` list because the existing history presentation and date semantics are LeetCode-specific.
+
+Alternative considered: create a separate uncached `get_extra_daily_payload()` path. That duplicates cache, in-flight, date-resolution, and envelope-validation ownership and creates inconsistent request behavior.
+
+### Reuse the existing overview and unified detail interaction
+
+For one problem, `/daily_extra` uses the existing full problem embed/view builders with an additional-source daily footer. For multiple problems, it uses the existing overview embed/view builders, preserving upstream order and using each problem's own `source` and `id` in `problem|{source}|{problem_id}|view`.
+
+The overview builder receives localized daily-specific title/footer text. The generic problem-overview view gains an all-or-nothing safety decision shared with existing detail-button validation: every displayed item must have safe routing segments, every custom id must fit Discord limits, and the complete result set must fit within 25 buttons. An unsafe payload produces a localized command error and no partial overview.
+
+Alternative considered: add two daily-specific toggle buttons or edit the original message in place. That would introduce shared state and allow concurrent users to overwrite the same message.
+
+Alternative considered: add a daily-specific custom-id and interaction handler. The existing stateless problem action protocol already carries all required routing data.
+
+### Separate initial response visibility from detail visibility
+
+`public=false` remains the default and makes the initial direct card or overview ephemeral. `public=true` makes only that initial response public. Every overview `view` click continues to defer and respond ephemerally through the existing interaction handler, and the original overview is never edited.
+
+### Keep upstream availability and processing authoritative
+
+The command validates only the local `YYYY-MM-DD` shape before requesting data. A `404`/empty result becomes a localized source/date not-found response, `202` continues through `ApiProcessingError`, and network/rate-limit/generic failures reuse the existing localized API error flow. The bot does not copy Sheep/0x3f weekday or first-date rules.
+
+## Risks / Trade-offs
+
+- **An additional-source response contains more than 25 problems or an unsafe ID** → Reject the payload with a localized error instead of silently omitting buttons or creating an unrouteable interaction.
+- **The generic daily payload helper becomes harder to reason about** → Keep the target choice explicit, preserve existing positional domain calls, namespace cache keys, and cover domain/source isolation with focused tests.
+- **Additional-source titles or links are sparse** → Continue using the existing source-aware problem card and overview rendering; missing required routing/display fields fail closed rather than producing partial UI.
+- **A public overview exposes the list to everyone** → This is explicitly controlled by `public`; selected details remain ephemeral and stateless.
+- **A v0.4 backend rejects `source`** → `/daily_extra` reports the normal localized API failure while existing LeetCode commands retain v0.4 compatibility.
+
+## Migration Plan
+
+1. Deploy the command, locale keys, client method, payload changes, and tests together.
+2. Let the normal Discord command sync register `/daily_extra`; no data migration or configuration update is required.
+3. Roll back by reverting this change. Existing `/daily`, `/daily_cn`, scheduler, and database state remain compatible because their public contracts are unchanged.
+
+## Open Questions
+
+None. The approved first-stage scope is manual lookup only, with overview-first multi-problem display and ephemeral selected details.

--- a/openspec/changes/add-daily-extra-command/proposal.md
+++ b/openspec/changes/add-daily-extra-command/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The bot currently exposes only LeetCode daily challenges even though the configured oj-api-rs backend can return `sheep` and `0x3f` daily sources, including ordered multi-problem responses. A dedicated manual command is needed so users can query those sources without changing the existing `/daily`, `/daily_cn`, or scheduled-delivery behavior.
+
+## What Changes
+
+- Add a manual `/daily_extra` slash command with required `source` choices `sheep` and `0x3f`, plus optional `date` and `public` parameters.
+- Preserve the complete upstream `{date, source, problems}` envelope for additional daily sources.
+- Render a single returned problem as a full problem card; render multiple returned problems as an ordered overview with one existing unified problem-detail button per problem.
+- Keep each detail opened from the overview private to the clicking user, even when the initial overview is public.
+- Reject payloads that cannot be represented completely within Discord's 25-button and stable custom-id limits instead of attaching a partial view.
+- Scope daily payload reuse by request target and date so LeetCode domains, `sheep`, and `0x3f` cannot collide in the in-flight or short-lived cache.
+- Add localized command metadata and user-facing success/error text for all supported locales.
+- Preserve existing `/daily`, `/daily_cn`, oj-api-rs v0.4 LeetCode compatibility, and scheduled posting behavior.
+- No database, scheduler, configuration, or external dependency changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `daily-extra-command`: Defines manual additional-source retrieval, single- and multi-problem presentation, private detail interactions, localization, validation, and upstream error handling.
+
+### Modified Capabilities
+
+- `daily-request-deduplication`: Generalizes daily payload reuse from LeetCode domain/date keys to collision-free daily request target/date keys while retaining independent localized rendering.
+
+## Impact
+
+- Affected code and documentation: `src/bot/api_client.py`, `src/bot/cogs/slash_commands_cog.py`, `src/bot/utils/ui_helpers.py`, `src/bot/utils/ui_constants.py`, locale JSON files under `src/bot/i18n/locales/`, and `README.md`.
+- Reused interaction contract: `problem|{source}|{problem_id}|view` in `src/bot/cogs/interaction_handler_cog.py`; no new button protocol or interaction state store is introduced.
+- Affected tests: API daily query/envelope tests, daily payload reuse tests, slash-command tests, overview safety tests, interaction privacy regression tests, and locale parity tests.
+- Upstream dependency: oj-api-rs `GET /api/v1/daily?source={sheep|0x3f}&date={YYYY-MM-DD}` and its existing `200`, `202`, `400`, and `404` behavior.

--- a/openspec/changes/add-daily-extra-command/specs/daily-extra-command/spec.md
+++ b/openspec/changes/add-daily-extra-command/specs/daily-extra-command/spec.md
@@ -73,7 +73,7 @@ Every full problem detail opened from a `/daily_extra` overview SHALL be sent as
 - **AND** neither interaction SHALL overwrite the other user's response or the overview
 
 ### Requirement: Complete and safe overview interaction
-The bot SHALL attach a `/daily_extra` overview view only when every displayed problem can be represented completely within Discord's 25-button, label, row, and custom-id limits. It SHALL reject an unsafe payload with a localized error instead of attaching a partial button set.
+The bot SHALL attach a `/daily_extra` overview view only when every displayed problem can be represented completely within Discord's 25-button, label, row, custom-id, embed-field, and total-embed limits. It SHALL reject an unsafe payload with a localized error instead of attaching a partial button set.
 
 #### Scenario: Exact 25-problem boundary
 - **WHEN** an additional daily payload contains exactly 25 button-safe problems
@@ -88,6 +88,16 @@ The bot SHALL attach a `/daily_extra` overview view only when every displayed pr
 - **WHEN** any returned problem lacks a non-empty `source` or `id`, contains the custom-id separator in either routing segment, or would exceed a Discord label/custom-id limit
 - **THEN** the command SHALL send a localized payload error
 - **AND** it SHALL NOT send a partial overview
+
+#### Scenario: Oversized overview embed
+- **WHEN** the generated overview exceeds a Discord embed field or total-length limit
+- **THEN** the command SHALL send a localized payload error
+- **AND** it SHALL NOT send the invalid overview
+
+#### Scenario: Existing generic overview keeps its LeetCode source default
+- **WHEN** an existing `/problem` multi-problem response omits `source`
+- **THEN** its overview buttons SHALL continue to route with `leetcode` as the default source
+- **AND** `/daily_extra` SHALL continue to require an explicit source on every returned problem
 
 ### Requirement: Visibility, localization, and error handling
 The initial `/daily_extra` response SHALL be ephemeral by default and public only when `public=true`. Command metadata and all user-facing text SHALL be available in zh-TW, en-US, and zh-CN through the existing locale system.

--- a/openspec/changes/add-daily-extra-command/specs/daily-extra-command/spec.md
+++ b/openspec/changes/add-daily-extra-command/specs/daily-extra-command/spec.md
@@ -1,0 +1,147 @@
+## ADDED Requirements
+
+### Requirement: Manual additional daily command surface
+The bot SHALL expose a localized `/daily_extra` slash command with required `source`, optional `date`, and optional `public` parameters. The `source` parameter SHALL be constrained to the Discord choices `sheep` and `0x3f`; `date` SHALL use `YYYY-MM-DD` when present; and `public` SHALL default to `false`.
+
+#### Scenario: Query today's Sheep daily
+- **WHEN** a user runs `/daily_extra source:sheep` without a date
+- **THEN** the bot SHALL request the current Sheep daily challenge from oj-api-rs
+
+#### Scenario: Query a dated 0x3f daily
+- **WHEN** a user runs `/daily_extra source:0x3f date:2026-06-09`
+- **THEN** the bot SHALL request the 0x3f daily challenge for `2026-06-09`
+
+#### Scenario: Command source choices
+- **WHEN** Discord presents the `source` parameter for `/daily_extra`
+- **THEN** the available choices SHALL be exactly `sheep` and `0x3f`
+
+#### Scenario: Existing daily entry points remain unchanged
+- **WHEN** `/daily_extra` is registered
+- **THEN** `/daily` and `/daily_cn` SHALL retain their existing LeetCode domain behavior and parameters
+
+### Requirement: Additional daily source API contract
+The bot SHALL retrieve additional-source daily data through `GET /api/v1/daily` using `source={sheep|0x3f}` and optional `date`, without sending a LeetCode `domain`. It SHALL preserve the returned `{date, source, problems}` envelope and the complete upstream problem order.
+
+#### Scenario: Additional source request parameters
+- **WHEN** the bot fetches `/daily_extra source:sheep date:2026-06-02`
+- **THEN** the API request SHALL contain `source=sheep` and `date=2026-06-02`
+- **AND** the request SHALL NOT contain `domain`
+
+#### Scenario: Multiple problems preserve upstream order
+- **WHEN** oj-api-rs returns an ordered `problems` array with two or more problems
+- **THEN** the daily payload and displayed overview SHALL retain every returned problem in that order
+
+#### Scenario: LeetCode v0.4 compatibility remains bounded
+- **WHEN** an existing `/daily` or `/daily_cn` request receives the oj-api-rs v0.4 flat response
+- **THEN** the existing LeetCode normalization SHALL continue to wrap it in the current daily envelope
+- **AND** `/daily_extra` SHALL NOT add a legacy flat-response fallback for additional sources
+
+### Requirement: Single and multiple problem presentation
+The command SHALL render a valid one-problem daily envelope as a full problem card and a valid multi-problem envelope as a localized ordered overview. Both presentations SHALL identify the selected daily source and resolved date.
+
+#### Scenario: Single additional daily problem
+- **WHEN** oj-api-rs returns exactly one problem for `/daily_extra`
+- **THEN** the bot SHALL send that problem's full source-aware card and existing problem action view
+- **AND** the card footer SHALL identify the additional daily source and resolved date
+
+#### Scenario: Multiple additional daily problems
+- **WHEN** oj-api-rs returns between 2 and 25 button-safe problems for `/daily_extra`
+- **THEN** the bot SHALL send one overview containing every problem in upstream order
+- **AND** the overview title or footer SHALL identify the additional daily source and resolved date
+- **AND** the overview SHALL contain one detail button per displayed problem in the same order
+
+#### Scenario: Detail buttons reuse the unified protocol
+- **WHEN** a multi-problem overview creates a problem detail button
+- **THEN** its custom id SHALL use `problem|{problem.source}|{problem.id}|view`
+- **AND** no daily-specific interaction state or custom-id format SHALL be required
+
+### Requirement: Multi-user detail privacy
+Every full problem detail opened from a `/daily_extra` overview SHALL be sent as an ephemeral response to the clicking user. The handler SHALL NOT edit or replace the original overview.
+
+#### Scenario: Detail from a private overview
+- **WHEN** a user clicks a problem button on an ephemeral `/daily_extra` overview
+- **THEN** the bot SHALL send that problem's full card ephemerally to that user
+
+#### Scenario: Detail from a public overview
+- **WHEN** a user clicks a problem button on a public `/daily_extra` overview
+- **THEN** the bot SHALL still send the full problem card ephemerally to the clicking user
+- **AND** the public overview SHALL remain unchanged
+
+#### Scenario: Independent concurrent clicks
+- **WHEN** two users click different problem buttons on the same public overview
+- **THEN** each user SHALL receive an independent ephemeral problem card
+- **AND** neither interaction SHALL overwrite the other user's response or the overview
+
+### Requirement: Complete and safe overview interaction
+The bot SHALL attach a `/daily_extra` overview view only when every displayed problem can be represented completely within Discord's 25-button, label, row, and custom-id limits. It SHALL reject an unsafe payload with a localized error instead of attaching a partial button set.
+
+#### Scenario: Exact 25-problem boundary
+- **WHEN** an additional daily payload contains exactly 25 button-safe problems
+- **THEN** the overview SHALL contain exactly 25 buttons arranged with at most 5 buttons per row and at most 5 rows
+
+#### Scenario: More than 25 problems
+- **WHEN** an additional daily payload contains more than 25 problems
+- **THEN** the command SHALL send a localized payload-limit error
+- **AND** it SHALL NOT send a partial overview containing only the first 25 buttons
+
+#### Scenario: Unsafe routing fields
+- **WHEN** any returned problem lacks a non-empty `source` or `id`, contains the custom-id separator in either routing segment, or would exceed a Discord label/custom-id limit
+- **THEN** the command SHALL send a localized payload error
+- **AND** it SHALL NOT send a partial overview
+
+### Requirement: Visibility, localization, and error handling
+The initial `/daily_extra` response SHALL be ephemeral by default and public only when `public=true`. Command metadata and all user-facing text SHALL be available in zh-TW, en-US, and zh-CN through the existing locale system.
+
+#### Scenario: Default private initial response
+- **WHEN** a user runs `/daily_extra` without `public=true`
+- **THEN** the command SHALL defer and send its initial card, overview, or error ephemerally
+
+#### Scenario: Public initial response
+- **WHEN** a user runs `/daily_extra public:true`
+- **THEN** the command SHALL defer and send its initial card or overview publicly
+
+#### Scenario: Invalid date format
+- **WHEN** a user supplies a date that does not match `YYYY-MM-DD`
+- **THEN** the command SHALL send the existing localized date-format error with the requested visibility
+- **AND** it SHALL NOT call the API
+
+#### Scenario: Source/date unavailable
+- **WHEN** oj-api-rs returns `404` for the requested additional source and date
+- **THEN** the command SHALL send a localized not-found response identifying the request context
+
+#### Scenario: Additional daily data is processing
+- **WHEN** oj-api-rs returns `202` with `fetching` or `ingestion_required` status
+- **THEN** the command SHALL send the existing localized processing response
+
+#### Scenario: API failure classes
+- **WHEN** the request fails because of a network error, rate limit, or other API error
+- **THEN** the command SHALL use the existing localized API error mapping
+
+#### Scenario: Locale key parity
+- **WHEN** `/daily_extra` locale keys are added
+- **THEN** zh-TW, en-US, and zh-CN SHALL expose the same key set within Discord's metadata and message length limits
+
+### Requirement: Manual-only first-stage scope
+The `/daily_extra` capability SHALL be available only through explicit user invocation in this change and SHALL NOT alter scheduled daily delivery, guild settings, or persistence.
+
+#### Scenario: Scheduled delivery remains LeetCode-only
+- **WHEN** existing scheduled daily jobs execute after `/daily_extra` is deployed
+- **THEN** they SHALL retain their current LeetCode domain behavior and SHALL NOT schedule Sheep or 0x3f delivery
+
+#### Scenario: No configuration or database migration
+- **WHEN** `/daily_extra` is deployed
+- **THEN** no guild configuration field, database table, or migration SHALL be added for additional daily sources
+
+## PBT Properties
+
+### Property: Ordered complete overview
+- **INVARIANT**: Every accepted multi-problem payload yields exactly one overview button for every displayed problem in the same order
+- **FALSIFICATION**: Generate valid problem lists of size 2 through 25 and compare payload order, overview line order, button labels, and custom ids
+
+### Property: All-or-nothing daily detail affordance
+- **INVARIANT**: A `/daily_extra` multi-problem result is either rendered with a complete safe button set or rejected without a partial overview
+- **FALSIFICATION**: Generate lists exceeding 25 items or containing one unsafe routing segment and assert no subset of buttons is sent
+
+### Property: Selected detail isolation
+- **INVARIANT**: The visibility of the initial overview never changes the ephemeral visibility of a selected problem detail
+- **FALSIFICATION**: Exercise private and public initial responses with multiple simulated clickers and assert every `view` follow-up is ephemeral and the original response is never edited

--- a/openspec/changes/add-daily-extra-command/specs/daily-request-deduplication/spec.md
+++ b/openspec/changes/add-daily-extra-command/specs/daily-request-deduplication/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: In-flight daily payload reuse
+The system SHALL reuse in-flight or short-lived cached daily challenge payload data for identical daily request-target/date requests within one bot process. A request target SHALL be namespaced by kind and value so LeetCode domains (`domain:com`, `domain:cn`) and additional sources (`source:sheep`, `source:0x3f`) cannot collide.
+
+#### Scenario: Concurrent current LeetCode daily payload requests
+- **WHEN** multiple daily challenge flows request the current daily payload for the same LeetCode domain while the first request is still processing
+- **THEN** the system SHALL await the same in-flight payload work instead of starting duplicate upstream daily and history fetches
+
+#### Scenario: Concurrent current additional-source payload requests
+- **WHEN** multiple `/daily_extra` flows request the current daily payload for the same additional source while the first request is still processing
+- **THEN** the system SHALL await the same in-flight payload work instead of starting duplicate upstream daily fetches
+
+#### Scenario: Short burst after payload completion
+- **WHEN** a daily challenge flow requests the same request target and date shortly after a successful payload fetch
+- **THEN** the system SHALL reuse the cached payload without calling the matching upstream daily API again
+
+#### Scenario: Request target cache isolation
+- **WHEN** otherwise identical requests target `domain:com`, `domain:cn`, `source:sheep`, or `source:0x3f`
+- **THEN** each distinct target SHALL use a separate in-flight and cache entry
+- **AND** no target SHALL receive another target's daily payload
+
+#### Scenario: Additional sources skip LeetCode history fan-out
+- **WHEN** the system builds a payload for `source:sheep` or `source:0x3f`
+- **THEN** it SHALL preserve the complete daily `problems` array
+- **AND** it SHALL NOT issue LeetCode historical same-day requests
+
+#### Scenario: Existing LeetCode payload compatibility
+- **WHEN** the system builds a payload for `domain:com` or `domain:cn`
+- **THEN** it SHALL retain the first problem as `challenge_info`, preserve the complete `problems` array, and retain existing historical-problem behavior
+
+#### Scenario: Locale-specific rendering remains independent
+- **WHEN** two interactions render the same cached daily payload using different resolved locales
+- **THEN** the system SHALL build separate localized Discord embeds and views from the shared payload
+
+## PBT Properties
+
+### Property: Daily target cache partition
+- **INVARIANT**: Cache identity is a function of request-target namespace, target value, and explicit/resolved date
+- **FALSIFICATION**: Generate the same dates across `domain:com`, `domain:cn`, `source:sheep`, and `source:0x3f` and assert only identical target/date pairs share work

--- a/openspec/changes/add-daily-extra-command/tasks.md
+++ b/openspec/changes/add-daily-extra-command/tasks.md
@@ -1,0 +1,31 @@
+## 1. Additional daily API and payload contract
+
+- [x] 1.1 Add API-client tests for `source`-only daily requests, optional dates, full envelope preservation, and unchanged v0.4 LeetCode normalization.
+- [x] 1.2 Add `OjApiClient.get_daily_by_source()` while retaining the existing `get_daily(domain, date)` public contract.
+- [x] 1.3 Add payload tests for complete ordered problem preservation, target/date in-flight reuse, target cache isolation, and no LeetCode history fan-out for additional sources.
+- [x] 1.4 Extend `get_daily_payload()` with an explicit additional-source target, namespaced cache keys, a complete `problems` list, and backward-compatible LeetCode payload fields.
+
+## 2. Safe reusable multi-problem presentation
+
+- [x] 2.1 Add UI-helper tests for ordered overview buttons, exact 25-button layout, unsafe routing fields, over-limit payloads, and localized daily footer overrides.
+- [x] 2.2 Generalize the existing problem-detail button safety decision and make `create_problems_overview_view()` return no view unless every displayed problem is safely representable.
+- [x] 2.3 Extend the overview embed builder only as needed to accept localized daily-specific footer text without changing existing `/problem` output.
+
+## 3. Manual `/daily_extra` command
+
+- [x] 3.1 Add slash-command tests for exact source choices, current/date requests, default-private and explicit-public initial responses, single-problem cards, ordered multi-problem overviews, invalid dates, missing data, unsafe payloads, and API error mapping.
+- [x] 3.2 Implement `/daily_extra source:<sheep|0x3f> [date] [public]` by composing the source-aware payload and existing problem/overview builders.
+- [x] 3.3 Add `sheep` and `0x3f` display labels plus zh-TW, en-US, and zh-CN metadata, footer, not-found, and payload-limit translations with locale key parity.
+- [x] 3.4 Add an interaction regression test proving an overview `view` click remains ephemeral and does not edit the original overview; do not add a new interaction route.
+
+## 4. Documentation and compatibility
+
+- [x] 4.1 Document `/daily_extra`, its sources, date/public parameters, multi-problem overview, and private selected details in `README.md`.
+- [x] 4.2 Verify `/daily`, `/daily_cn`, scheduled daily delivery, and oj-api-rs v0.4 LeetCode compatibility remain unchanged.
+
+## 5. Validation
+
+- [x] 5.1 Run focused API, payload, UI, slash-command, interaction, i18n, and history-date tests.
+- [x] 5.2 Run `openspec validate add-daily-extra-command --strict --no-interactive`.
+- [x] 5.3 Run `uv run --extra dev ruff check .` and `uv run --extra dev pytest` with writable runtime log/cache paths.
+  - Ruff passes. The full suite has 229 passing tests and 3 pre-existing worktree-only path assertions caused by the intentionally symlinked `config.toml` and `data/data.db` resolving to the main checkout.

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -191,6 +191,12 @@ class OjApiClient:
             return None
         return self._normalize_daily_response(response, domain)
 
+    async def get_daily_by_source(self, source: str, date: str | None = None) -> dict | None:
+        params = {"source": source}
+        if date:
+            params["date"] = date
+        return await self._request("GET", "daily", params=params)
+
     async def resolve(self, query: str) -> dict | None:
         return await self._request("GET", f"resolve/{quote(query, safe='')}")
 

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -21,6 +21,7 @@ from bot.utils.ui_helpers import (
     get_daily_payload,
     get_source_label,
     get_source_logo_url,
+    is_embed_within_limits,
     send_api_error,
     send_daily_challenge,
 )
@@ -115,7 +116,7 @@ class SlashCommandsCog(commands.Cog):
                 date=resolved_date,
             )
 
-            overview_view = create_problems_overview_view(problems, "com")
+            overview_view = create_problems_overview_view(problems, "com", default_source=None)
             if overview_view is None:
                 await interaction.followup.send(
                     i18n.t("errors.validation.daily_extra_unsafe_payload", locale),
@@ -158,6 +159,12 @@ class SlashCommandsCog(commands.Cog):
                     bot=self.bot,
                     locale=locale,
                 )
+                if not is_embed_within_limits(embed):
+                    await interaction.followup.send(
+                        i18n.t("errors.validation.daily_extra_unsafe_payload", locale),
+                        ephemeral=not public,
+                    )
+                    return
 
             await interaction.followup.send(embed=embed, view=view, ephemeral=not public)
             self.logger.info(

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -60,6 +60,126 @@ class SlashCommandsCog(commands.Cog):
         else:
             await send_daily_challenge(bot=self.bot, interaction=interaction, domain="cn", ephemeral=not public)
 
+    @app_commands.command(name="daily_extra", description=app_commands.locale_str("daily_extra.description"))
+    @app_commands.describe(
+        source=app_commands.locale_str("daily_extra.source"),
+        date=app_commands.locale_str("daily_extra.date"),
+        public=app_commands.locale_str("daily_extra.public"),
+    )
+    @app_commands.choices(
+        source=[
+            app_commands.Choice(name="Sheep", value="sheep"),
+            app_commands.Choice(name="0x3f", value="0x3f"),
+        ]
+    )
+    async def daily_extra_command(
+        self,
+        interaction: discord.Interaction,
+        source: str,
+        date: str = None,
+        public: bool = False,
+    ):
+        await interaction.response.defer(ephemeral=not public)
+        locale = _get_locale(self.bot, interaction)
+        i18n = self.bot.i18n
+
+        if date and not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+            await interaction.followup.send(
+                i18n.t("errors.validation.date_format", locale),
+                ephemeral=not public,
+            )
+            return
+
+        try:
+            payload = await get_daily_payload(self.bot, date_str=date, source=source)
+            source_label = get_source_label(source)
+            requested_date = date or (payload.get("resolved_date") if payload else i18n.t("ui.embed.today", locale))
+            if not payload:
+                await interaction.followup.send(
+                    i18n.t(
+                        "errors.validation.daily_extra_not_found",
+                        locale,
+                        source_label=source_label,
+                        date=requested_date,
+                    ),
+                    ephemeral=not public,
+                )
+                return
+
+            problems = payload["problems"]
+            resolved_date = payload["resolved_date"]
+            footer_text = i18n.t(
+                "ui.embed.daily_extra_footer",
+                locale,
+                source_label=source_label,
+                date=resolved_date,
+            )
+
+            overview_view = create_problems_overview_view(problems, "com")
+            if overview_view is None:
+                await interaction.followup.send(
+                    i18n.t("errors.validation.daily_extra_unsafe_payload", locale),
+                    ephemeral=not public,
+                )
+                return
+
+            if len(problems) == 1:
+                problem = problems[0]
+                embed = await create_problem_embed(
+                    problem_info=problem,
+                    bot=self.bot,
+                    domain="com",
+                    is_daily=False,
+                    date_str=resolved_date,
+                    locale=locale,
+                    footer_text=footer_text,
+                )
+                view = await create_problem_view(
+                    problem_info=problem,
+                    bot=self.bot,
+                    domain="com",
+                    locale=locale,
+                )
+            else:
+                view = overview_view
+                embed = create_problems_overview_embed(
+                    problems,
+                    "com",
+                    title=i18n.t(
+                        "ui.embed.daily_extra_title",
+                        locale,
+                        source_label=source_label,
+                        date=resolved_date,
+                        count=len(problems),
+                    ),
+                    source_label=source_label,
+                    footer_icon_url=get_source_logo_url(source),
+                    footer_text=footer_text,
+                    bot=self.bot,
+                    locale=locale,
+                )
+
+            await interaction.followup.send(embed=embed, view=view, ephemeral=not public)
+            self.logger.info(
+                "Sent %s daily challenge for %s with %d problems to user %s",
+                source,
+                resolved_date,
+                len(problems),
+                interaction.user.name,
+            )
+        except ApiProcessingError:
+            await send_api_error(interaction, "processing", self.bot, ephemeral=not public)
+        except ApiNetworkError:
+            await send_api_error(interaction, "network", self.bot, ephemeral=not public)
+        except ApiRateLimitError:
+            await send_api_error(interaction, "rate_limit", self.bot, ephemeral=not public)
+        except ApiError as error:
+            self.logger.error("API error in daily_extra command: %s", error)
+            await send_api_error(interaction, "generic", self.bot, ephemeral=not public)
+        except Exception as error:
+            self.logger.error("Unexpected error in daily_extra command: %s", error, exc_info=True)
+            await send_api_error(interaction, "generic", self.bot, ephemeral=not public)
+
     async def _daily_by_date(self, interaction: discord.Interaction, domain: str, date: str, public: bool):
         locale = _get_locale(self.bot, interaction)
         i18n = self.bot.i18n

--- a/src/bot/i18n/locales/en-US.json
+++ b/src/bot/i18n/locales/en-US.json
@@ -27,7 +27,9 @@
       "invalid_limit": "Limit must be at least 1.",
       "random_not_found": "No problems found matching {filters}. Please adjust your filters and try again.",
       "random_no_filter": "no filters",
-      "random_error": "❌ An unexpected error occurred while fetching a random problem. Please try again."
+      "random_error": "❌ An unexpected error occurred while fetching a random problem. Please try again.",
+      "daily_extra_not_found": "No {source_label} daily problems were found for {date}.",
+      "daily_extra_unsafe_payload": "The daily problem set cannot be displayed safely. Please try again later."
     },
     "unexpected": "An unexpected error occurred: {error}",
     "config": {
@@ -87,6 +89,9 @@
       "similar_questions": "🔍 Similar Questions ({count}{suffix})",
       "history_problems": "History Problems",
       "daily_footer": "📅 LeetCode Daily Challenge | {date}",
+      "daily_extra_title": "📅 {source_label} Daily ({date}, {count} problems)",
+      "daily_extra_footer": "📅 {source_label} Daily | {date}",
+      "today": "today",
       "problem_footer": "📖 LeetCode Problem",
       "random_footer": "🎲 Random Problem",
       "similar_footer": "🔍 Similar Problems",
@@ -156,6 +161,12 @@
       "description": "Get LeetCode Daily Challenge (LCCN)",
       "date": "Query daily challenge for a specific date (YYYY-MM-DD), defaults to today, earliest 2020-04-01",
       "public": "Whether to show the reply publicly (default: private)"
+    },
+    "daily_extra": {
+      "description": "Query Sheep or 0x3f daily problems",
+      "source": "Daily problem source",
+      "date": "Date (YYYY-MM-DD), defaults to today",
+      "public": "Show the initial response publicly (details remain private)"
     },
     "problem": {
       "description": "Query problem information by ID",

--- a/src/bot/i18n/locales/zh-CN.json
+++ b/src/bot/i18n/locales/zh-CN.json
@@ -27,7 +27,9 @@
       "invalid_limit": "数量至少为 1",
       "random_not_found": "没有找到符合 {filters} 的题目，请调整筛选条件后重试。",
       "random_no_filter": "无筛选条件",
-      "random_error": "❌ 随机题目时发生未预期错误，请稍后重试。"
+      "random_error": "❌ 随机题目时发生未预期错误，请稍后重试。",
+      "daily_extra_not_found": "找不到 {source_label} 在 {date} 的每日题目。",
+      "daily_extra_unsafe_payload": "每日题目数量或题号无法安全显示，请稍后再试。"
     },
     "unexpected": "发生未预期错误：{error}",
     "config": {
@@ -87,6 +89,9 @@
       "similar_questions": "🔍 Similar Questions ({count}{suffix})",
       "history_problems": "History Problems",
       "daily_footer": "📅 LeetCode Daily Challenge | {date}",
+      "daily_extra_title": "📅 {source_label} Daily（{date}，共 {count} 题）",
+      "daily_extra_footer": "📅 {source_label} Daily | {date}",
+      "today": "今天",
       "problem_footer": "📖 LeetCode Problem",
       "random_footer": "🎲 Random Problem",
       "similar_footer": "🔍 Similar Problems",
@@ -156,6 +161,12 @@
       "description": "获取 LeetCode 每日挑战 (LCCN)",
       "date": "查询指定日期的每日挑战 (YYYY-MM-DD 格式)，不填则为今天，最早为 2020-04-01",
       "public": "是否公开显示回复 (默认为私密回复)"
+    },
+    "daily_extra": {
+      "description": "查询 Sheep 或 0x3f 每日题目",
+      "source": "每日题目来源",
+      "date": "指定日期（YYYY-MM-DD），不填则为今天",
+      "public": "是否公开显示初始回复（题目详情仍为私密）"
     },
     "problem": {
       "description": "根据题号查询题目信息",

--- a/src/bot/i18n/locales/zh-TW.json
+++ b/src/bot/i18n/locales/zh-TW.json
@@ -27,7 +27,9 @@
       "invalid_limit": "數量至少為 1",
       "random_not_found": "沒有找到符合 {filters} 的題目，請調整篩選條件後重試。",
       "random_no_filter": "無篩選條件",
-      "random_error": "❌ 隨機題目時發生未預期錯誤，請稍後重試。"
+      "random_error": "❌ 隨機題目時發生未預期錯誤，請稍後重試。",
+      "daily_extra_not_found": "找不到 {source_label} 在 {date} 的每日題目。",
+      "daily_extra_unsafe_payload": "每日題目數量或題號無法安全顯示，請稍後再試。"
     },
     "unexpected": "發生未預期錯誤：{error}",
     "config": {
@@ -87,6 +89,9 @@
       "similar_questions": "🔍 Similar Questions ({count}{suffix})",
       "history_problems": "History Problems",
       "daily_footer": "📅 LeetCode Daily Challenge | {date}",
+      "daily_extra_title": "📅 {source_label} Daily（{date}，共 {count} 題）",
+      "daily_extra_footer": "📅 {source_label} Daily | {date}",
+      "today": "今天",
       "problem_footer": "📖 LeetCode Problem",
       "random_footer": "🎲 Random Problem",
       "similar_footer": "🔍 Similar Problems",
@@ -136,6 +141,12 @@
       "description": "取得 LeetCode 每日挑戰 (LCCN)",
       "date": "查詢指定日期的每日挑戰 (YYYY-MM-DD 格式)，不填則為今天，最早為 2020-04-01",
       "public": "是否公開顯示回覆 (預設為私密回覆)"
+    },
+    "daily_extra": {
+      "description": "查詢 Sheep 或 0x3f 每日題目",
+      "source": "每日題目來源",
+      "date": "指定日期（YYYY-MM-DD），不填則為今天",
+      "public": "是否公開顯示初始回覆（題目詳情仍為私密）"
     },
     "problem": {
       "description": "根據題號查詢題目資訊",

--- a/src/bot/utils/ui_constants.py
+++ b/src/bot/utils/ui_constants.py
@@ -92,6 +92,8 @@ SOURCE_LABELS = {
     "luogu": "Luogu",
     "codeforces": "Codeforces",
     "spoj": "SPOJ",
+    "sheep": "Sheep",
+    "0x3f": "0x3f",
 }
 
 SOURCE_LOGOS = {

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -34,6 +34,7 @@ from .ui_constants import (
     MAX_BUTTON_CUSTOM_ID_LENGTH,
     MAX_BUTTON_LABEL_LENGTH,
     MAX_DAILY_SIMILAR_FIELD_LENGTH,
+    MAX_EMBED_LENGTH,
     MAX_FIELD_LENGTH,
     MAX_PROBLEMS_PER_OVERVIEW,
     MAX_SIMILAR_RESULT_DETAIL_BUTTONS,
@@ -332,6 +333,7 @@ def _can_create_problem_detail_view(
     *,
     max_items: int,
     was_truncated: bool = False,
+    default_source: str | None = None,
 ) -> bool:
     return (
         bool(problems)
@@ -339,10 +341,10 @@ def _can_create_problem_detail_view(
         and len(problems) <= max_items
         and all(
             isinstance(problem, dict)
-            and _is_safe_problem_button_segment(problem.get("source"))
+            and _is_safe_problem_button_segment(problem.get("source", default_source))
             and _is_safe_problem_button_segment(problem.get("id"), max_length=MAX_BUTTON_LABEL_LENGTH)
             and max(
-                len(_build_problem_custom_id(problem.get("source"), problem.get("id"), action))
+                len(_build_problem_custom_id(problem.get("source", default_source), problem.get("id"), action))
                 for action in ("desc", "translate", "inspire", "similar")
             )
             <= MAX_BUTTON_CUSTOM_ID_LENGTH
@@ -830,16 +832,29 @@ def create_problems_overview_embed(
     return embed
 
 
-def create_problems_overview_view(problems: List[Dict[str, Any]], domain: str) -> discord.ui.View | None:
+def is_embed_within_limits(embed: discord.Embed) -> bool:
+    return len(embed) <= MAX_EMBED_LENGTH and all(len(field.value) <= MAX_FIELD_LENGTH for field in embed.fields)
+
+
+def create_problems_overview_view(
+    problems: List[Dict[str, Any]],
+    domain: str,
+    *,
+    default_source: str | None = "leetcode",
+) -> discord.ui.View | None:
     """Create a view with buttons for each problem"""
-    if not _can_create_problem_detail_view(problems, max_items=MAX_PROBLEMS_PER_OVERVIEW):
+    if not _can_create_problem_detail_view(
+        problems,
+        max_items=MAX_PROBLEMS_PER_OVERVIEW,
+        default_source=default_source,
+    ):
         return None
 
     view = discord.ui.View()
 
     for i, problem in enumerate(problems):
         emoji = get_problem_emoji(problem)
-        source, problem_id = _normalize_problem_button_segments(problem["source"], problem["id"])
+        source, problem_id = _normalize_problem_button_segments(problem.get("source", default_source), problem["id"])
 
         button = discord.ui.Button(
             style=discord.ButtonStyle.secondary,

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -327,17 +327,35 @@ def _build_problem_custom_id(source: Any, problem_id: Any, action: str) -> str:
     return PROBLEM_CUSTOM_ID_FMT.format(source=normalized_source, pid=normalized_problem_id, action=action)
 
 
-def _can_create_similar_result_view(results: List[Dict[str, Any]], *, was_truncated: bool) -> bool:
+def _can_create_problem_detail_view(
+    problems: List[Dict[str, Any]],
+    *,
+    max_items: int,
+    was_truncated: bool = False,
+) -> bool:
     return (
-        bool(results)
+        bool(problems)
         and not was_truncated
-        and len(results) <= MAX_SIMILAR_RESULT_DETAIL_BUTTONS
+        and len(problems) <= max_items
         and all(
-            _is_safe_problem_button_segment(item.get("source"))
-            and _is_safe_problem_button_segment(item.get("id"), max_length=MAX_BUTTON_LABEL_LENGTH)
-            and len(_build_problem_custom_id(item.get("source"), item.get("id"), "view")) <= MAX_BUTTON_CUSTOM_ID_LENGTH
-            for item in results
+            isinstance(problem, dict)
+            and _is_safe_problem_button_segment(problem.get("source"))
+            and _is_safe_problem_button_segment(problem.get("id"), max_length=MAX_BUTTON_LABEL_LENGTH)
+            and max(
+                len(_build_problem_custom_id(problem.get("source"), problem.get("id"), action))
+                for action in ("desc", "translate", "inspire", "similar")
+            )
+            <= MAX_BUTTON_CUSTOM_ID_LENGTH
+            for problem in problems
         )
+    )
+
+
+def _can_create_similar_result_view(results: List[Dict[str, Any]], *, was_truncated: bool) -> bool:
+    return _can_create_problem_detail_view(
+        results,
+        max_items=MAX_SIMILAR_RESULT_DETAIL_BUTTONS,
+        was_truncated=was_truncated,
     )
 
 
@@ -734,6 +752,7 @@ def create_problems_overview_embed(
     footer_icon_url: Optional[str] = LEETCODE_LOGO_URL,
     bot: Any = None,
     locale: str = "zh-TW",
+    footer_text: Optional[str] = None,
 ) -> discord.Embed:
     """Create an overview embed showing all problems with basic info in user-provided order"""
     i18n = bot.i18n if bot else None
@@ -797,33 +816,36 @@ def create_problems_overview_embed(
             inline=False,
         )
 
-    footer_text = (
+    resolved_footer_text = footer_text or (
         i18n.t("ui.embed.problems_overview", locale, source_label=source_label)
         if i18n
         else f"📋 {source_label} Problems Overview"
     )
     if footer_icon_url:
-        embed.set_footer(text=footer_text, icon_url=footer_icon_url)
+        embed.set_footer(text=resolved_footer_text, icon_url=footer_icon_url)
     else:
-        embed.set_footer(text=footer_text)
+        embed.set_footer(text=resolved_footer_text)
     embed.timestamp = datetime.now(timezone.utc)
 
     return embed
 
 
-def create_problems_overview_view(problems: List[Dict[str, Any]], domain: str) -> discord.ui.View:
+def create_problems_overview_view(problems: List[Dict[str, Any]], domain: str) -> discord.ui.View | None:
     """Create a view with buttons for each problem"""
+    if not _can_create_problem_detail_view(problems, max_items=MAX_PROBLEMS_PER_OVERVIEW):
+        return None
+
     view = discord.ui.View()
 
-    for i, problem in enumerate(problems[:MAX_PROBLEMS_PER_OVERVIEW]):
+    for i, problem in enumerate(problems):
         emoji = get_problem_emoji(problem)
-        source = problem.get("source", "leetcode")
+        source, problem_id = _normalize_problem_button_segments(problem["source"], problem["id"])
 
         button = discord.ui.Button(
             style=discord.ButtonStyle.secondary,
-            label=f"{problem['id']}",
+            label=problem_id,
             emoji=emoji,
-            custom_id=_build_problem_custom_id(source, problem["id"], "view"),
+            custom_id=_build_problem_custom_id(source, problem_id, "view"),
             row=i // 5,
         )
         view.add_item(button)
@@ -930,17 +952,27 @@ _DAILY_PAYLOAD_CACHE_TTL_SECONDS = 60
 _CURRENT_DAILY_PAYLOAD_KEY = "__current__"
 
 
-def _get_primary_daily_problem(response: dict[str, Any] | None) -> dict[str, Any] | None:
+def _get_daily_problems(response: dict[str, Any] | None) -> list[dict[str, Any]] | None:
     if not response:
         return None
     problems = response.get("problems")
-    if not isinstance(problems, list) or not problems or not isinstance(problems[0], dict):
+    if (
+        not isinstance(problems, list)
+        or not problems
+        or not all(isinstance(problem, dict) for problem in problems)
+    ):
         return None
 
-    problem = dict(problems[0])
+    resolved = [dict(problem) for problem in problems]
     if response.get("date"):
-        problem["date"] = response["date"]
-    return problem
+        for problem in resolved:
+            problem["date"] = response["date"]
+    return resolved
+
+
+def _get_primary_daily_problem(response: dict[str, Any] | None) -> dict[str, Any] | None:
+    problems = _get_daily_problems(response)
+    return problems[0] if problems else None
 
 
 def _get_daily_payload_state(
@@ -1010,32 +1042,55 @@ async def _fetch_daily_payload(
     domain: str,
     date_str: str | None,
     fallback_date: str,
+    *,
+    source: str | None = None,
 ) -> dict[str, Any] | None:
-    if date_str:
+    if source is not None:
+        daily_response = await bot.api.get_daily_by_source(source, date_str)
+    elif date_str:
         daily_response = await bot.api.get_daily(domain, date_str)
     else:
         daily_response = await bot.api.get_daily(domain)
-    challenge_info = _get_primary_daily_problem(daily_response)
-    if not challenge_info:
+
+    problems = _get_daily_problems(daily_response)
+    if not problems:
         return None
 
-    history_anchor = daily_response.get("date") or date_str or fallback_date
-    history_problems = await _fetch_daily_history(bot, domain, history_anchor)
+    resolved_date = daily_response.get("date") or date_str or fallback_date
+    history_problems = [] if source is not None else await _fetch_daily_history(bot, domain, resolved_date)
     return {
-        "challenge_info": challenge_info,
+        "challenge_info": problems[0],
+        "problems": problems,
         "history_problems": history_problems,
-        "resolved_date": history_anchor,
+        "resolved_date": resolved_date,
+        "daily_source": daily_response.get("source")
+        or source
+        or ("leetcode.cn" if domain == "cn" else "leetcode.com"),
     }
 
 
-async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None = None) -> dict[str, Any] | None:
-    fallback_date = datetime.now(pytz.UTC).strftime("%Y-%m-%d")
-    cache_key = (domain, date_str or f"{_CURRENT_DAILY_PAYLOAD_KEY}:{fallback_date}")
+async def get_daily_payload(
+    bot: Any,
+    domain: str = "com",
+    date_str: str | None = None,
+    *,
+    source: str | None = None,
+) -> dict[str, Any] | None:
+    fallback_timezone = pytz.timezone("Asia/Taipei") if source is not None else pytz.UTC
+    fallback_date = datetime.now(fallback_timezone).strftime("%Y-%m-%d")
+    target_key = f"source:{source}" if source is not None else f"domain:{domain}"
+    cache_key = (target_key, date_str or f"{_CURRENT_DAILY_PAYLOAD_KEY}:{fallback_date}")
     cache, in_flight, lock = _get_daily_payload_state(bot)
 
     async def fetch_and_cleanup() -> dict[str, Any] | None:
         try:
-            return await _fetch_daily_payload(bot, domain, date_str, fallback_date)
+            return await _fetch_daily_payload(
+                bot,
+                domain,
+                date_str,
+                fallback_date,
+                source=source,
+            )
         finally:
             current_task = asyncio.current_task()
             async with lock:
@@ -1067,7 +1122,7 @@ async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None 
             cache[cache_key] = (inserted_at, payload)
             actual_date = payload.get("resolved_date")
             if actual_date and (date_str or payload["challenge_info"].get("date")):
-                cache[(domain, actual_date)] = (inserted_at, payload)
+                cache[(target_key, actual_date)] = (inserted_at, payload)
     return payload
 
 

--- a/tests/test_daily_extra_command.py
+++ b/tests/test_daily_extra_command.py
@@ -14,6 +14,7 @@ from bot.utils.ui_helpers import (
     create_problem_view,
     create_problems_overview_embed,
     create_problems_overview_view,
+    is_embed_within_limits,
 )
 
 
@@ -114,6 +115,12 @@ async def test_daily_overview_view_accepts_longest_safe_follow_up_action():
     assert max(len(button.custom_id) for button in detail_view.children) == 100
 
 
+def test_daily_overview_view_can_require_explicit_source():
+    problem = {key: value for key, value in _problem("100A").items() if key != "source"}
+
+    assert create_problems_overview_view([problem], "com", default_source=None) is None
+
+
 def test_daily_overview_embed_accepts_daily_footer_override():
     problems = [_problem("100A"), _problem("200B")]
 
@@ -129,6 +136,16 @@ def test_daily_overview_embed_accepts_daily_footer_override():
     assert isinstance(embed, discord.Embed)
     assert embed.title == "Sheep Daily | 2026-06-02"
     assert embed.footer.text == "Sheep Daily | 2026-06-02"
+
+
+def test_overview_embed_rejects_total_length_when_individual_fields_fit():
+    embed = discord.Embed()
+    for index in range(6):
+        embed.add_field(name=str(index), value="x" * 1000)
+
+    assert all(len(field.value) <= 1024 for field in embed.fields)
+    assert len(embed) > 6000
+    assert is_embed_within_limits(embed) is False
 
 
 def test_daily_extra_source_choices_are_exact():
@@ -195,7 +212,8 @@ async def test_daily_extra_multiple_problems_uses_ordered_overview(monkeypatch):
         "get_daily_payload",
         AsyncMock(return_value=_payload("sheep", problems)),
     )
-    overview_embed = MagicMock(return_value=sentinel.embed)
+    embed = discord.Embed(title="Safe overview")
+    overview_embed = MagicMock(return_value=embed)
     overview_view = MagicMock(return_value=sentinel.view)
     monkeypatch.setattr(slash_commands_module, "create_problems_overview_embed", overview_embed)
     monkeypatch.setattr(slash_commands_module, "create_problems_overview_view", overview_view)
@@ -211,9 +229,35 @@ async def test_daily_extra_multiple_problems_uses_ordered_overview(monkeypatch):
     assert overview_embed.call_args.args[0] == problems
     assert overview_view.call_args.args[0] == problems
     interaction.followup.send.assert_awaited_once_with(
-        embed=sentinel.embed,
+        embed=embed,
         view=sentinel.view,
         ephemeral=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_daily_extra_rejects_oversized_overview_embed(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    problems = [_problem(str(index)) | {"title": "x" * 300} for index in range(5)]
+    monkeypatch.setattr(
+        slash_commands_module,
+        "get_daily_payload",
+        AsyncMock(return_value=_payload("sheep", problems)),
+    )
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="sheep",
+        date="2026-06-02",
+        public=False,
+    )
+
+    interaction.followup.send.assert_awaited_once_with(
+        "errors.validation.daily_extra_unsafe_payload",
+        ephemeral=True,
     )
 
 

--- a/tests/test_daily_extra_command.py
+++ b/tests/test_daily_extra_command.py
@@ -1,0 +1,404 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, sentinel
+
+import discord
+import pytest
+from discord.ext import commands
+
+from bot.api_client import ApiError, ApiNetworkError, ApiProcessingError, ApiRateLimitError
+from bot.cogs import slash_commands_cog as slash_commands_module
+from bot.cogs.slash_commands_cog import SlashCommandsCog
+from bot.utils.ui_helpers import (
+    create_problem_view,
+    create_problems_overview_embed,
+    create_problems_overview_view,
+)
+
+
+def _problem(problem_id: str, *, source: str = "codeforces") -> dict:
+    return {
+        "id": problem_id,
+        "source": source,
+        "slug": problem_id,
+        "title": f"Problem {problem_id}",
+        "difficulty": None,
+        "ac_rate": None,
+        "rating": 1200,
+        "tags": ["implementation"],
+        "link": f"https://example.com/{problem_id}",
+    }
+
+
+def _make_bot():
+    bot = MagicMock(spec=commands.Bot)
+    bot.api = AsyncMock()
+    bot.llm = MagicMock()
+    bot.llm_pro = MagicMock()
+    bot.config = SimpleNamespace(default_locale="zh-TW")
+    bot.i18n = MagicMock()
+    bot.i18n.resolve_locale = MagicMock(return_value="zh-TW")
+    bot.i18n.t = MagicMock(side_effect=lambda key, locale, **kwargs: key.format(**kwargs))
+    return bot
+
+
+def _make_interaction():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.response = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = MagicMock(name="tester", display_name="tester")
+    interaction.user.name = "tester"
+    interaction.guild = MagicMock(id=123)
+    interaction.guild_locale = None
+    interaction.locale = discord.Locale.taiwan_chinese
+    return interaction
+
+
+def _payload(source: str, problems: list[dict]) -> dict:
+    return {
+        "challenge_info": problems[0],
+        "problems": problems,
+        "history_problems": [],
+        "resolved_date": "2026-06-02",
+        "daily_source": source,
+    }
+
+
+@pytest.mark.asyncio
+async def test_daily_overview_view_preserves_exact_25_problem_order():
+    problems = [_problem(str(index)) for index in range(1, 26)]
+
+    view = create_problems_overview_view(problems, "com")
+
+    assert view is not None
+    assert [button.label for button in view.children] == [str(index) for index in range(1, 26)]
+    assert [button.row for button in view.children[:6]] == [0, 0, 0, 0, 0, 1]
+    assert view.children[-1].row == 4
+
+
+@pytest.mark.asyncio
+async def test_daily_overview_view_rejects_more_than_25_problems():
+    problems = [_problem(str(index)) for index in range(1, 27)]
+
+    assert create_problems_overview_view(problems, "com") is None
+
+
+@pytest.mark.asyncio
+async def test_daily_overview_view_rejects_unsafe_routing_fields():
+    problems = [_problem("100A"), _problem("bad|id")]
+
+    assert create_problems_overview_view(problems, "com") is None
+
+
+@pytest.mark.asyncio
+async def test_daily_overview_view_rejects_id_that_overflows_follow_up_action():
+    problem = _problem("x" * 72)
+
+    assert len(f"problem|codeforces|{problem['id']}|view") == 96
+    assert len(f"problem|codeforces|{problem['id']}|translate") == 101
+    assert create_problems_overview_view([problem], "com") is None
+
+
+@pytest.mark.asyncio
+async def test_daily_overview_view_accepts_longest_safe_follow_up_action():
+    problem = _problem("x" * 71)
+
+    view = create_problems_overview_view([problem], "com")
+    detail_view = await create_problem_view(problem, _make_bot())
+
+    assert view is not None
+    assert len(f"problem|codeforces|{problem['id']}|translate") == 100
+    assert max(len(button.custom_id) for button in detail_view.children) == 100
+
+
+def test_daily_overview_embed_accepts_daily_footer_override():
+    problems = [_problem("100A"), _problem("200B")]
+
+    embed = create_problems_overview_embed(
+        problems,
+        "com",
+        title="Sheep Daily | 2026-06-02",
+        source_label="Sheep",
+        footer_icon_url=None,
+        footer_text="Sheep Daily | 2026-06-02",
+    )
+
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "Sheep Daily | 2026-06-02"
+    assert embed.footer.text == "Sheep Daily | 2026-06-02"
+
+
+def test_daily_extra_source_choices_are_exact():
+    source_parameter = next(
+        parameter for parameter in SlashCommandsCog.daily_extra_command.parameters if parameter.name == "source"
+    )
+
+    assert [(choice.name, choice.value) for choice in source_parameter.choices] == [
+        ("Sheep", "sheep"),
+        ("0x3f", "0x3f"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source", "date", "public"),
+    [
+        ("sheep", None, False),
+        ("0x3f", "2026-06-02", True),
+    ],
+)
+async def test_daily_extra_single_problem_uses_source_payload_and_visibility(
+    monkeypatch,
+    source,
+    date,
+    public,
+):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    problem = _problem("100A")
+    get_payload = AsyncMock(return_value=_payload(source, [problem]))
+    create_embed = AsyncMock(return_value=sentinel.embed)
+    create_view = AsyncMock(return_value=sentinel.view)
+    monkeypatch.setattr(slash_commands_module, "get_daily_payload", get_payload)
+    monkeypatch.setattr(slash_commands_module, "create_problem_embed", create_embed)
+    monkeypatch.setattr(slash_commands_module, "create_problem_view", create_view)
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source=source,
+        date=date,
+        public=public,
+    )
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=not public)
+    get_payload.assert_awaited_once_with(bot, date_str=date, source=source)
+    interaction.followup.send.assert_awaited_once_with(
+        embed=sentinel.embed,
+        view=sentinel.view,
+        ephemeral=not public,
+    )
+
+
+@pytest.mark.asyncio
+async def test_daily_extra_multiple_problems_uses_ordered_overview(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    problems = [_problem("100A"), _problem("200B")]
+    monkeypatch.setattr(
+        slash_commands_module,
+        "get_daily_payload",
+        AsyncMock(return_value=_payload("sheep", problems)),
+    )
+    overview_embed = MagicMock(return_value=sentinel.embed)
+    overview_view = MagicMock(return_value=sentinel.view)
+    monkeypatch.setattr(slash_commands_module, "create_problems_overview_embed", overview_embed)
+    monkeypatch.setattr(slash_commands_module, "create_problems_overview_view", overview_view)
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="sheep",
+        date="2026-06-02",
+        public=True,
+    )
+
+    assert overview_embed.call_args.args[0] == problems
+    assert overview_view.call_args.args[0] == problems
+    interaction.followup.send.assert_awaited_once_with(
+        embed=sentinel.embed,
+        view=sentinel.view,
+        ephemeral=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_daily_extra_rejects_invalid_date_before_api(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    get_payload = AsyncMock()
+    monkeypatch.setattr(slash_commands_module, "get_daily_payload", get_payload)
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="sheep",
+        date="2026/06/02",
+        public=False,
+    )
+
+    get_payload.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once_with(
+        "errors.validation.date_format",
+        ephemeral=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_daily_extra_reports_not_found(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    monkeypatch.setattr(slash_commands_module, "get_daily_payload", AsyncMock(return_value=None))
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="0x3f",
+        date="2026-06-02",
+        public=False,
+    )
+
+    bot.i18n.t.assert_any_call(
+        "errors.validation.daily_extra_not_found",
+        "zh-TW",
+        source_label="0x3f",
+        date="2026-06-02",
+    )
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_daily_extra_rejects_unsafe_multi_problem_payload(monkeypatch):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    problems = [_problem("100A"), _problem("bad|id")]
+    monkeypatch.setattr(
+        slash_commands_module,
+        "get_daily_payload",
+        AsyncMock(return_value=_payload("sheep", problems)),
+    )
+    monkeypatch.setattr(
+        slash_commands_module,
+        "create_problems_overview_view",
+        MagicMock(return_value=None),
+    )
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="sheep",
+        date="2026-06-02",
+        public=False,
+    )
+
+    interaction.followup.send.assert_awaited_once_with(
+        "errors.validation.daily_extra_unsafe_payload",
+        ephemeral=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "problem",
+    [
+        {key: value for key, value in _problem("100A").items() if key != "source"},
+        {key: value for key, value in _problem("100A").items() if key != "id"},
+        _problem("100A", source="bad|source"),
+        _problem("bad|id"),
+        _problem("x" * 72),
+    ],
+)
+async def test_daily_extra_rejects_unsafe_single_problem_payload(monkeypatch, problem):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    create_embed = AsyncMock(return_value=sentinel.embed)
+    create_view = AsyncMock(return_value=sentinel.view)
+    monkeypatch.setattr(
+        slash_commands_module,
+        "get_daily_payload",
+        AsyncMock(return_value=_payload("sheep", [problem])),
+    )
+    monkeypatch.setattr(slash_commands_module, "create_problem_embed", create_embed)
+    monkeypatch.setattr(slash_commands_module, "create_problem_view", create_view)
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="sheep",
+        date="2026-06-02",
+        public=False,
+    )
+
+    interaction.followup.send.assert_awaited_once_with(
+        "errors.validation.daily_extra_unsafe_payload",
+        ephemeral=True,
+    )
+    create_embed.assert_not_awaited()
+    create_view.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception", "error_kind"),
+    [
+        (ApiProcessingError("processing"), "processing"),
+        (ApiNetworkError("network"), "network"),
+        (ApiRateLimitError(5), "rate_limit"),
+        (ApiError(500, "failed"), "generic"),
+    ],
+)
+async def test_daily_extra_maps_api_errors(monkeypatch, exception, error_kind):
+    bot = _make_bot()
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+    monkeypatch.setattr(
+        slash_commands_module,
+        "get_daily_payload",
+        AsyncMock(side_effect=exception),
+    )
+    send_error = AsyncMock()
+    monkeypatch.setattr(slash_commands_module, "send_api_error", send_error)
+
+    await cog.daily_extra_command.callback(
+        cog,
+        interaction,
+        source="sheep",
+        date=None,
+        public=False,
+    )
+
+    send_error.assert_awaited_once_with(
+        interaction,
+        error_kind,
+        bot,
+        ephemeral=True,
+    )
+
+
+def test_daily_extra_locale_keys_have_parity():
+    locale_dir = Path(__file__).parents[1] / "src/bot/i18n/locales"
+    documents = {path.stem: json.loads(path.read_text(encoding="utf-8")) for path in locale_dir.glob("*.json")}
+
+    def flatten(value, prefix=""):
+        keys = set()
+        for key, child in value.items():
+            path = f"{prefix}.{key}" if prefix else key
+            keys.add(path)
+            if isinstance(child, dict):
+                keys.update(flatten(child, path))
+        return keys
+
+    expected = flatten(documents["zh-TW"])
+    required = {
+        "commands.daily_extra.description",
+        "commands.daily_extra.source",
+        "commands.daily_extra.date",
+        "commands.daily_extra.public",
+        "errors.validation.daily_extra_not_found",
+        "errors.validation.daily_extra_unsafe_payload",
+        "ui.embed.daily_extra_title",
+        "ui.embed.daily_extra_footer",
+        "ui.embed.today",
+    }
+    assert required <= expected
+    assert flatten(documents["en-US"]) == expected
+    assert flatten(documents["zh-CN"]) == expected

--- a/tests/test_daily_payload_reuse.py
+++ b/tests/test_daily_payload_reuse.py
@@ -38,9 +38,43 @@ def _daily_response(date: str = "2026-06-03", domain: str = "com") -> dict:
     }
 
 
+def _extra_daily_response(source: str = "sheep", date: str = "2026-06-02") -> dict:
+    return {
+        "date": date,
+        "source": source,
+        "problems": [
+            {
+                "id": "100A",
+                "source": "codeforces",
+                "slug": "100A",
+                "title": "First",
+                "difficulty": None,
+                "ac_rate": None,
+                "rating": 1200,
+                "tags": ["implementation"],
+                "link": "https://codeforces.com/problemset/problem/100/A",
+            },
+            {
+                "id": "200B",
+                "source": "codeforces",
+                "slug": "200B",
+                "title": "Second",
+                "difficulty": None,
+                "ac_rate": None,
+                "rating": 1400,
+                "tags": ["math"],
+                "link": "https://codeforces.com/problemset/problem/200/B",
+            },
+        ],
+    }
+
+
 def _make_bot():
     bot = MagicMock(spec=commands.Bot)
-    bot.api = SimpleNamespace(get_daily=AsyncMock(return_value=_daily_response()))
+    bot.api = SimpleNamespace(
+        get_daily=AsyncMock(return_value=_daily_response()),
+        get_daily_by_source=AsyncMock(),
+    )
     bot.llm = MagicMock()
     bot.llm_pro = MagicMock()
     bot.config = SimpleNamespace(default_locale="zh-TW")
@@ -109,6 +143,106 @@ async def test_get_daily_preserves_current_envelope_response():
 
     assert result is current_response
     api._request.assert_awaited_once_with("GET", "daily", params={"domain": "com"})
+
+
+@pytest.mark.asyncio
+async def test_get_daily_by_source_sends_source_without_domain():
+    response = _extra_daily_response("sheep", "2026-06-02")
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=response)
+
+    result = await api.get_daily_by_source("sheep", "2026-06-02")
+
+    assert result is response
+    api._request.assert_awaited_once_with(
+        "GET",
+        "daily",
+        params={"source": "sheep", "date": "2026-06-02"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_daily_by_source_omits_date_when_not_requested():
+    response = _extra_daily_response("0x3f")
+    api = OjApiClient("http://test")
+    api._session = AsyncMock()
+    api._request = AsyncMock(return_value=response)
+
+    result = await api.get_daily_by_source("0x3f")
+
+    assert result is response
+    api._request.assert_awaited_once_with("GET", "daily", params={"source": "0x3f"})
+
+
+@pytest.mark.asyncio
+async def test_extra_daily_payload_preserves_order_and_skips_history(monkeypatch):
+    bot = _make_bot()
+    response = _extra_daily_response()
+    bot.api.get_daily_by_source.return_value = response
+    history = AsyncMock()
+    monkeypatch.setattr(ui_helpers, "_fetch_daily_history", history)
+
+    payload = await get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+
+    assert [problem["id"] for problem in payload["problems"]] == ["100A", "200B"]
+    assert payload["challenge_info"]["id"] == "100A"
+    assert payload["daily_source"] == "sheep"
+    assert payload["resolved_date"] == "2026-06-02"
+    assert payload["history_problems"] == []
+    history.assert_not_awaited()
+    bot.api.get_daily_by_source.assert_awaited_once_with("sheep", "2026-06-02")
+
+
+@pytest.mark.asyncio
+async def test_daily_payload_cache_isolated_by_target(monkeypatch):
+    bot = _make_bot()
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
+    bot.api.get_daily_by_source.side_effect = [
+        _extra_daily_response("sheep"),
+        _extra_daily_response("0x3f"),
+    ]
+
+    leetcode = await get_daily_payload(bot, "com", "2026-06-02")
+    sheep = await get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+    zero_x3f = await get_daily_payload(bot, date_str="2026-06-02", source="0x3f")
+    sheep_again = await get_daily_payload(bot, date_str="2026-06-02", source="sheep")
+
+    assert leetcode["daily_source"] == "leetcode.com"
+    assert sheep["daily_source"] == "sheep"
+    assert zero_x3f["daily_source"] == "0x3f"
+    assert sheep_again is sheep
+    assert bot.api.get_daily.await_count == 1
+    assert bot.api.get_daily_by_source.await_count == 2
+    assert ("domain:com", "2026-06-02") in bot._daily_payload_cache
+    assert ("source:sheep", "2026-06-02") in bot._daily_payload_cache
+    assert ("source:0x3f", "2026-06-02") in bot._daily_payload_cache
+
+
+@pytest.mark.asyncio
+async def test_extra_daily_payload_coalesces_identical_in_flight_requests():
+    bot = _make_bot()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def fetch(source, date=None):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _extra_daily_response(source, date or "2026-06-02")
+
+    bot.api.get_daily_by_source.side_effect = fetch
+    first = asyncio.create_task(get_daily_payload(bot, date_str="2026-06-02", source="sheep"))
+    await started.wait()
+    second = asyncio.create_task(get_daily_payload(bot, date_str="2026-06-02", source="sheep"))
+    release.set()
+
+    first_payload, second_payload = await asyncio.gather(first, second)
+
+    assert first_payload is second_payload
+    assert calls == 1
 
 
 @pytest.mark.asyncio
@@ -190,7 +324,7 @@ async def test_get_daily_payload_ignores_completed_failed_in_flight_task(monkeyp
     with pytest.raises(ApiProcessingError):
         await failed_task
 
-    bot._daily_payload_in_flight = {("com", "2026-06-03"): failed_task}
+    bot._daily_payload_in_flight = {("domain:com", "2026-06-03"): failed_task}
 
     payload = await get_daily_payload(bot, "com", "2026-06-03")
 
@@ -220,14 +354,14 @@ async def test_get_daily_payload_prunes_expired_cache_entries(monkeypatch):
         "history_problems": [],
         "resolved_date": "2026-06-01",
     }
-    bot._daily_payload_cache = {("com", "2026-06-01"): (0.0, old_payload)}
+    bot._daily_payload_cache = {("domain:com", "2026-06-01"): (0.0, old_payload)}
     monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda anchor_date: [])
     monkeypatch.setattr(ui_helpers.time, "monotonic", lambda: 61.0)
 
     await get_daily_payload(bot, "com", "2026-06-03")
 
-    assert ("com", "2026-06-01") not in bot._daily_payload_cache
-    assert ("com", "2026-06-03") in bot._daily_payload_cache
+    assert ("domain:com", "2026-06-01") not in bot._daily_payload_cache
+    assert ("domain:com", "2026-06-03") in bot._daily_payload_cache
 
 
 @pytest.mark.asyncio

--- a/tests/test_interaction_handler.py
+++ b/tests/test_interaction_handler.py
@@ -1,6 +1,6 @@
 # tests/test_interaction_handler.py
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, sentinel
 
 import discord
 import pytest
@@ -423,6 +423,68 @@ class TestInteractionHandler:
         assert "view" in kwargs
         assert kwargs["embed"].title.startswith("🔴 P1001:")
         assert kwargs["view"].children[0].custom_id == "problem|luogu|P1001|desc"
+        assert kwargs["ephemeral"] is True
+        mock_interaction.edit_original_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_problem_view_clicks_are_private_and_independent_per_user(self, cog, mock_bot, monkeypatch):
+        def make_click(user_id: int, problem_id: str):
+            interaction = AsyncMock(spec=discord.Interaction)
+            interaction.type = discord.InteractionType.component
+            interaction.data = {"custom_id": f"problem|codeforces|{problem_id}|view"}
+            interaction.user = MagicMock(id=user_id, name=f"user-{user_id}")
+            interaction.response = AsyncMock()
+            interaction.response.defer = AsyncMock()
+            interaction.followup = AsyncMock()
+            interaction.followup.send = AsyncMock()
+            interaction.guild = MagicMock(id=987654321)
+            interaction.guild_locale = None
+            interaction.locale = discord.Locale.taiwan_chinese
+            return interaction
+
+        first = make_click(1, "100A")
+        second = make_click(2, "200B")
+        problems = {
+            "100A": {
+                "id": "100A",
+                "source": "codeforces",
+                "title": "First",
+                "link": "https://example.com/100A",
+            },
+            "200B": {
+                "id": "200B",
+                "source": "codeforces",
+                "title": "Second",
+                "link": "https://example.com/200B",
+            },
+        }
+
+        async def get_problem(source, problem_id):
+            assert source == "codeforces"
+            return problems[problem_id]
+
+        async def create_embed(*, problem_info, **kwargs):
+            return sentinel.first_embed if problem_info["id"] == "100A" else sentinel.second_embed
+
+        async def create_view(*, problem_info, **kwargs):
+            return sentinel.first_view if problem_info["id"] == "100A" else sentinel.second_view
+
+        mock_bot.api.get_problem.side_effect = get_problem
+        monkeypatch.setattr(interaction_handler_module, "create_problem_embed", AsyncMock(side_effect=create_embed))
+        monkeypatch.setattr(interaction_handler_module, "create_problem_view", AsyncMock(side_effect=create_view))
+
+        await asyncio.gather(cog.on_interaction(first), cog.on_interaction(second))
+
+        first.response.defer.assert_awaited_once_with(ephemeral=True)
+        second.response.defer.assert_awaited_once_with(ephemeral=True)
+        first_kwargs = first.followup.send.await_args.kwargs
+        second_kwargs = second.followup.send.await_args.kwargs
+        assert first_kwargs["ephemeral"] is True
+        assert second_kwargs["ephemeral"] is True
+        assert first_kwargs["embed"] is sentinel.first_embed
+        assert second_kwargs["embed"] is sentinel.second_embed
+        first.edit_original_response.assert_not_awaited()
+        second.edit_original_response.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/tests/test_slash_problem_command.py
+++ b/tests/test_slash_problem_command.py
@@ -125,6 +125,19 @@ def _make_atcoder_problem(problem_id: str) -> dict:
     }
 
 
+def _make_legacy_leetcode_problem(problem_id: str) -> dict:
+    return {
+        "id": problem_id,
+        "slug": f"problem-{problem_id}",
+        "title": f"Problem {problem_id}",
+        "difficulty": "Easy",
+        "ac_rate": 50.0,
+        "rating": None,
+        "tags": ["Array"],
+        "link": f"https://leetcode.com/problems/problem-{problem_id}/",
+    }
+
+
 def _make_luogu_problem(problem_id: str, difficulty: str = "入门") -> dict:
     return {
         "id": problem_id,
@@ -225,6 +238,35 @@ async def test_problem_command_atcoder_multiple_sends_overview_buttons():
         assert emoji_value == NON_DIFFICULTY_EMOJI
         assert button.custom_id.startswith("problem|atcoder|")
         assert button.custom_id.endswith("|view")
+
+
+@pytest.mark.asyncio
+async def test_problem_command_legacy_leetcode_multiple_defaults_missing_source_for_overview_buttons():
+    bot = _make_bot()
+
+    async def _resolve(query):
+        return {"problem": _make_legacy_leetcode_problem(query)}
+
+    bot.api.resolve.side_effect = _resolve
+    cog = SlashCommandsCog(bot)
+    interaction = _make_interaction()
+
+    await cog.problem_command.callback(
+        cog,
+        interaction,
+        problem_ids="1,2",
+        domain="com",
+        public=False,
+        message=None,
+        title=None,
+        source=None,
+    )
+
+    _, kwargs = interaction.followup.send.call_args
+    assert [button.custom_id for button in kwargs["view"].children] == [
+        "problem|leetcode|1|view",
+        "problem|leetcode|2|view",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add `/daily_extra` for Sheep and 0x3f with optional date and public visibility
- preserve ordered multi-problem daily envelopes with collision-free caching and safe private detail views
- add localized strings, OpenSpec/Aegis records, documentation, and regression coverage

## Test plan

- [x] focused daily/API/UI/interaction/schedule/history suite: 93 passed
- [x] `uv run --extra dev ruff check .`
- [x] `openspec validate add-daily-extra-command --strict --no-interactive`
- [x] Aegis workspace structure check
- [x] full suite with local `config.toml` and `data/data.db` symlinks temporarily removed: passed (exit code 0)
- [x] restored both symlinks and verified their original targets afterward