### PR TITLE
✨ feat(daily): add independent source push schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 ## ✨ Features
 
-- 🔄 **Automatic Daily Challenge**: Automatically posts the daily challenge to Discord
-- ⏰ **Scheduled Delivery**: Configure a posting time and timezone for each server
+- 🔄 **Automatic Daily Challenges**: Schedule `leetcode.com`, `sheep`, and `0x3f` problem sets
+- ⏰ **Independent Scheduled Delivery**: Configure up to three independent daily pushes per server, each with its own channel, role, time, and timezone
 - 🎮 **Slash Commands**: Simple slash-command interface for daily problems, lookup, recent submissions, and settings
 - 🌐 **Multi-server Support**: Each Discord server keeps its own configuration
 - 🔔 **Custom Notifications**: Configure the target channel and optional role mention
@@ -88,6 +88,8 @@ uv run python data/cleanup_runtime_db.py --db-path /path/to/data.db --skip-vacuu
 
 The helper creates a timestamped backup, rebuilds the runtime schema from `data/init_db_schema.sql`, migrates `server_settings`, `llm_translate_results`, and `llm_inspire_results` when present, and runs `VACUUM` unless you pass `--skip-vacuum`.
 
+The bot also migrates the former single-push `server_settings` schema automatically at startup. Before changing the schema it creates a timestamped `.pre-push-redesign.bak` SQLite backup, then each legacy schedule is migrated to the `leetcode.com` source. The backup is retained for operator rollback and is never read by the normal runtime path.
+
 If you need to initialize an empty database manually:
 
 ```bash
@@ -151,14 +153,15 @@ See `config.toml.example` for all available options.
 | `/problem <problem_ids> [source] [domain] [public] [message] [title]` | Query one or multiple problems<br>• `problem_ids`: Single ID or comma-separated IDs<br>• Supports `source:id` format such as `atcoder:abc001_a` or `leetcode:1`<br>• `source`: Problem source filter or hint<br>• `domain`: `com` or `cn` for LeetCode (default: `com`)<br>• `public`: Show the response publicly<br>• `message`: Optional personal note (max 500 chars)<br>• `title`: Custom title for multi-problem mode (max 100 chars)<br>• Supports up to 20 problems per query | None |
 | `/recent <username> [limit] [public]` | View recent accepted submissions for a user<br>• `username`: LeetCode username (LCUS only)<br>• `limit`: Number of submissions (1-50, default: 20)<br>• `public`: Show the response publicly | None |
 | `/similar [query] [problem] [top_k] [source] [public]` | Find similar problems through the configured remote API backend<br>• `query`: Free-text query (optional when `problem` is provided)<br>• `problem`: Existing problem ID or URL<br>• `top_k`: Number of results (default: 5, capped at 20)<br>• `source`: Problem source filter<br>• `public`: Show the response publicly | None |
-| `/config [channel] [role] [time] [timezone] [clear_role] [reset]` | View or update daily-challenge server settings<br>• No parameters: Show current settings<br>• `channel`: Notification channel (required on first setup)<br>• `role`: Role to mention with daily challenges<br>• `time`: Posting time in `HH:MM` or `H:MM` format<br>• `timezone`: Timezone such as `Asia/Taipei` or `UTC+8`<br>• `clear_role`: Remove the configured role mention<br>• `reset`: Reset all settings and stop scheduling<br>• `reset` cannot be combined with other options | Manage Guild |
+| `/config [source] [channel] [role] [time] [timezone] [clear_role] [language] [remove] [reset]` | View or update daily-push settings<br>• No parameters: Show the shared language and all configured pushes<br>• `source`: `leetcode.com`, `sheep`, or `0x3f`; push updates default to `leetcode.com` when omitted<br>• `channel`, `role`, `time`, `timezone`, and `clear_role`: Update only the selected source<br>• `language`: Shared by every push in the server<br>• `remove`: Remove only the explicitly selected source after confirmation<br>• `reset`: Reset the language and all pushes after confirmation | Manage Guild |
 
 ### Server setup for daily notifications
 
-1. Run `/config channel:<channel>` for the initial setup.
-2. Optionally set `role`, `time`, and `timezone` in the same command or later updates.
-3. Use `/config` with no arguments to review the current configuration.
-4. Use `/config reset:true` to reset all settings and stop scheduling.
+1. Run `/config channel:<channel>` to create the default `leetcode.com` push.
+2. Add optional independent pushes with `/config source:sheep channel:<channel>` and `/config source:0x3f channel:<channel>`.
+3. Set `role`, `time`, and `timezone` independently by including the target `source`; each server can have at most one push per source.
+4. Use `/config` with no arguments to review the shared language and all pushes.
+5. Use `/config source:<source> remove:true` to remove one push, or `/config reset:true` to remove every server setting.
 
 ### Multi-Problem Features
 
@@ -249,8 +252,11 @@ When querying multiple problems, the bot displays:
 /config
 /config channel:#general
 /config channel:#general time:08:00 timezone:UTC+8
-/config role:@DailyChallenge
-/config clear_role:true
+/config source:sheep channel:#sheep-daily time:09:00 timezone:Asia/Taipei
+/config source:0x3f channel:#daily-problems role:@DailyChallenge
+/config source:sheep clear_role:true
+/config language:en-US
+/config source:0x3f remove:true
 /config reset:true
 ```
 

--- a/data/cleanup_runtime_db.py
+++ b/data/cleanup_runtime_db.py
@@ -12,6 +12,7 @@ DEFAULT_DB_PATH = DATA_DIR / "data.db"
 DEFAULT_INIT_SCRIPT_PATH = DATA_DIR / "init_db_schema.sql"
 PRESERVED_TABLES = (
     "server_settings",
+    "daily_push_settings",
     "llm_translate_results",
     "llm_inspire_results",
 )
@@ -133,6 +134,28 @@ def get_select_expressions(
     return expressions
 
 
+def copy_legacy_daily_push_settings(conn: sqlite3.Connection) -> bool:
+    if table_exists(conn, "old", "daily_push_settings"):
+        return False
+
+    legacy_columns = set(get_table_columns(conn, "old", "server_settings"))
+    required_columns = {"server_id", "channel_id", "role_id", "post_time", "timezone"}
+    if not required_columns.issubset(legacy_columns):
+        return False
+
+    conn.execute(
+        """
+        INSERT INTO main.daily_push_settings
+            (server_id, source, channel_id, role_id, post_time, timezone, created_at, updated_at)
+        SELECT
+            server_id, 'leetcode.com', channel_id, role_id, post_time, timezone,
+            created_at, updated_at
+        FROM old.server_settings
+        """
+    )
+    return True
+
+
 def rebuild_database(db_path: Path, init_script_path: Path, temp_db_path: Path) -> list[str]:
     init_sql = init_script_path.read_text(encoding="utf-8")
     copied_tables: list[str] = []
@@ -159,6 +182,9 @@ def rebuild_database(db_path: Path, init_script_path: Path, temp_db_path: Path) 
                 f"SELECT {select_columns} FROM old.{quote_ident(table_name)}"
             )
             copied_tables.append(table_name)
+
+        if copy_legacy_daily_push_settings(conn):
+            copied_tables.append("daily_push_settings")
 
     return copied_tables
 

--- a/data/init_db_schema.sql
+++ b/data/init_db_schema.sql
@@ -3,13 +3,22 @@
 
 CREATE TABLE IF NOT EXISTS server_settings (
     server_id INTEGER PRIMARY KEY,
-    channel_id INTEGER NOT NULL,
-    role_id INTEGER,
-    post_time TEXT DEFAULT '00:00',
-    timezone TEXT DEFAULT 'UTC',
     language TEXT NOT NULL DEFAULT 'zh-TW',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS daily_push_settings (
+    server_id INTEGER NOT NULL,
+    source TEXT NOT NULL CHECK (source IN ('leetcode.com', 'sheep', '0x3f')),
+    channel_id INTEGER NOT NULL,
+    role_id INTEGER,
+    post_time TEXT NOT NULL DEFAULT '00:00',
+    timezone TEXT NOT NULL DEFAULT 'UTC',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (server_id, source),
+    FOREIGN KEY (server_id) REFERENCES server_settings(server_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS llm_translate_results (

--- a/docs/aegis/BASELINE-GOVERNANCE.md
+++ b/docs/aegis/BASELINE-GOVERNANCE.md
@@ -1,0 +1,54 @@
+# Baseline Governance
+
+## 1. Baseline Roles
+- Product / Requirement Baseline: problem, accepted behavior, success evidence,
+  non-goals, workflow constraints, and approved requirement/spec intent.
+- Architecture / Runtime Boundary Baseline: canonical owner, contract,
+  source-of-truth boundary, dependency direction, compatibility, runtime-ready
+  boundary, and retirement state.
+
+## 2. Design Defect
+A confirmed error, gap, contradiction, or wrong abstraction IN the relevant
+requirement, design, or baseline.
+- Fix the defective requirement/design/baseline first.
+- Then align implementation to the corrected baseline.
+- Do NOT patch implementation around a defective baseline.
+
+## 3. Implementation Drift
+Implementation, plan, review, or documentation has deviated from a confirmed,
+correct, unchanged requirement or architecture baseline.
+- Return to baseline via the simplest stable path.
+- Do NOT "update baseline to match drift" without explicit review.
+
+## 4. Compatibility Aliases
+- Architecture Defect = architecture-scoped Design Defect.
+- Architecture Drift = architecture-scoped Implementation Drift.
+- New findings should report Design Defect / Implementation Drift plus
+  `scope: requirements | architecture | both`.
+
+## 5. Baseline Check Protocol
+Before non-trivial changes:
+1. Read the latest Product / Requirement Baseline candidate.
+2. Read the latest Architecture / Runtime Boundary Baseline candidate.
+3. Compare current work against requirement acceptance and architecture owner /
+   contract boundaries.
+4. Check for new anti-patterns not recorded in known list.
+5. Report: aligned / Design Defect / Implementation Drift /
+   missing-authority / needs-clarification, with
+   `scope: requirements | architecture | both`.
+
+## 6. Architecture Review - 7 Dimensions
+After each non-trivial change:
+1. **Ownership integrity** - every component has exactly one canonical owner
+2. **Module boundaries** - no unauthorized cross-module coupling
+3. **Contract changes** - all API/signature/behavior contract changes documented
+4. **Cascade proliferation** - no new cascading dependency chains
+5. **Dependency direction** - dependencies flow toward stability
+6. **Retirement completeness** - old owners/fallbacks/paths removed or scheduled
+7. **Entropy flow** - net complexity decreased or stayed; no unjustified new entities
+
+## 7. Hard Boundaries
+- BASELINE-GOVERNANCE.md is the constitution for THIS project's Aegis workspace
+- Baseline snapshots in `baseline/` are evidence, not authority
+- ADRs in `adr/` record decisions; they do not replace baseline governance
+- This file is NEVER auto-updated - changes require explicit user review

--- a/docs/aegis/INDEX.md
+++ b/docs/aegis/INDEX.md
@@ -1,0 +1,20 @@
+# Aegis Workspace Index
+
+This index tracks files created under this project's `docs/aegis/` workspace.
+Entries are workspace records, not authoritative runtime decisions.
+
+| Date | Kind | Path | Title |
+| --- | --- | --- | --- |
+| 2026-07-18 | work | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md | Redesign daily push mechanism intent |
+| 2026-07-18 | work | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md | Redesign daily push mechanism checkpoint |
+| 2026-07-18 | work | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md | Redesign daily push mechanism evidence |
+| 2026-07-18 | work | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/99-reflection.md | Redesign daily push mechanism reflection |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json | Redesign daily push mechanism task intent draft |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/baseline-read-set-hint.json | Redesign daily push mechanism baseline read-set hint |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/baseline-usage-draft.json | Redesign daily push mechanism baseline usage draft |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/impact-statement-draft.json | Redesign daily push mechanism impact statement draft |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json | Redesign daily push mechanism todo checkpoint draft |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json | Redesign daily push mechanism drift check draft |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-openspec-strict-validation.json | 2026-07-18-redesign-daily-push-mechanism evidence openspec-strict-validation |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json | 2026-07-18-redesign-daily-push-mechanism evidence aegis-workspace-check |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json | 2026-07-18-redesign-daily-push-mechanism resume state hint |

--- a/docs/aegis/INDEX.md
+++ b/docs/aegis/INDEX.md
@@ -21,3 +21,7 @@ Entries are workspace records, not authoritative runtime decisions.
 | 2026-07-18 | plan | docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md | Redesign Daily Push Mechanism Implementation Plan |
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json | 2026-07-18-redesign-daily-push-mechanism evidence task1-schema-assets-green |
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task2-database-green.json | 2026-07-18-redesign-daily-push-mechanism evidence task2-database-green |
+| 2026-07-18 | adr | docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md | ADR-0001 - Normalize daily push ownership by source |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-final-full-verification-green.json | 2026-07-18-redesign-daily-push-mechanism evidence final-full-verification-green |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/gate-input-pack.json | 2026-07-18-redesign-daily-push-mechanism gate input pack |
+| 2026-07-18 | work | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/proof-bundle.md | 2026-07-18-redesign-daily-push-mechanism proof bundle |

--- a/docs/aegis/INDEX.md
+++ b/docs/aegis/INDEX.md
@@ -20,3 +20,4 @@ Entries are workspace records, not authoritative runtime decisions.
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json | 2026-07-18-redesign-daily-push-mechanism resume state hint |
 | 2026-07-18 | plan | docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md | Redesign Daily Push Mechanism Implementation Plan |
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json | 2026-07-18-redesign-daily-push-mechanism evidence task1-schema-assets-green |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task2-database-green.json | 2026-07-18-redesign-daily-push-mechanism evidence task2-database-green |

--- a/docs/aegis/INDEX.md
+++ b/docs/aegis/INDEX.md
@@ -19,3 +19,4 @@ Entries are workspace records, not authoritative runtime decisions.
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json | 2026-07-18-redesign-daily-push-mechanism evidence aegis-workspace-check |
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json | 2026-07-18-redesign-daily-push-mechanism resume state hint |
 | 2026-07-18 | plan | docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md | Redesign Daily Push Mechanism Implementation Plan |
+| 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json | 2026-07-18-redesign-daily-push-mechanism evidence task1-schema-assets-green |

--- a/docs/aegis/INDEX.md
+++ b/docs/aegis/INDEX.md
@@ -18,3 +18,4 @@ Entries are workspace records, not authoritative runtime decisions.
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-openspec-strict-validation.json | 2026-07-18-redesign-daily-push-mechanism evidence openspec-strict-validation |
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json | 2026-07-18-redesign-daily-push-mechanism evidence aegis-workspace-check |
 | 2026-07-18 | artifact | docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json | 2026-07-18-redesign-daily-push-mechanism resume state hint |
+| 2026-07-18 | plan | docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md | Redesign Daily Push Mechanism Implementation Plan |

--- a/docs/aegis/README.md
+++ b/docs/aegis/README.md
@@ -1,0 +1,10 @@
+# Aegis Project Workspace
+
+This directory stores project-local Aegis method-pack records.
+
+It may contain task intent, baseline snapshots, specs, plans, work checkpoints,
+evidence notes, and reflection records for this project.
+
+These files are advisory method-pack artifacts. They do not grant completion
+authority, produce authoritative `GateDecision`, or replace this project's
+existing authority docs.

--- a/docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md
+++ b/docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md
@@ -1,0 +1,49 @@
+# ADR-0001 - Normalize daily push ownership by source
+
+Status: `recorded-from-work`
+Date: `2026-07-18`
+
+## Source Evidence
+
+- Implemented and verified work in docs/aegis/work/2026-07-18-redesign-daily-push-mechanism plus commits c7a61c3 through 2b8165e.
+## Context
+
+The former server_settings row owned guild language and one delivery schedule, preventing independent leetcode.com, sheep, and 0x3f pushes. The redesign requires at most one push per supported source with independent delivery fields and shared guild language.
+
+## Decision
+
+Keep guild language in server_settings and make daily_push_settings the sole delivery owner, keyed by (server_id, source) with a fixed three-source constraint. Migrate each legacy schedule transactionally to leetcode.com after creating a timestamped SQLite backup, then remove legacy delivery columns and fallback access.
+
+## Alternatives Considered
+
+- Keep one combined server_settings row and add three sets of source-specific columns; rejected because it multiplies nullable columns and couples guild and delivery ownership.
+- Store arbitrary push rows without a fixed source constraint; rejected because the product limit is exactly one push for each of three supported sources and database enforcement prevents drift.
+## Consequences
+
+- Each server can configure up to three independently scheduled pushes while language remains shared.
+- Scheduler job identity, delivery deduplication, configuration, and API requests must carry canonical source identity end to end.
+- Legacy migration is one-way in the runtime database; rollback uses the retained pre-migration backup.
+## Compatibility Boundary
+
+Source-less /config delivery edits continue to target leetcode.com, existing manual domain-based /daily calls remain unchanged, and legacy reset IDs remain accepted.
+
+## Retirement Impact
+
+Retire delivery columns from server_settings, combined settings CRUD, server-only scheduler job IDs, hard-coded com delivery keys, and all runtime fallback reads after validated migration.
+
+## Baseline Sync
+
+- Needed: needed
+- Target: openspec/changes/redesign-daily-push-mechanism/design.md, data/init_db_schema.sql, and README.md
+- Action: cite unchanged
+- Reason: The approved OpenSpec design, normalized schema assets, and operator documentation were updated in the same change and already state the implemented owner, contract, compatibility, and retirement boundaries.
+
+## Evidence References
+
+- openspec/changes/redesign-daily-push-mechanism/design.md
+- tests/test_settings_database.py
+- tests/test_schedule_manager_cog.py
+- tests/test_config_command.py
+## Boundary
+
+This ADR is an advisory Aegis Method Pack record. It does not grant completion authority or replace project-authoritative architecture sources.

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -316,11 +316,11 @@ Use fixed `app_commands.Choice` values from the canonical source owner. Keep `re
 
 **Verification:** Run every command in the plan header.
 
-- [ ] Run targeted test groups once more and record exact results.
-- [ ] Run full pytest, Ruff check, Ruff format check, strict OpenSpec validation, lingering-reference searches for legacy push columns and server-only job IDs, and Aegis workspace check.
-- [ ] Fix only failures caused by this change, re-running the narrow failing command after each fix.
-- [ ] Re-run the entire verification set and perform the architecture review: ownership, boundaries, contract, dependency direction, legacy retirement, and complexity closure.
-- [ ] Update OpenSpec task checkboxes and Aegis checkpoint/evidence/drift records, then commit final scoped fixes/evidence with repository-history style.
+- [x] Run targeted test groups once more and record exact results.
+- [x] Run full pytest, Ruff check, Ruff format check, strict OpenSpec validation, lingering-reference searches for legacy push columns and server-only job IDs, and Aegis workspace check.
+- [x] Fix only failures caused by this change, re-running the narrow failing command after each fix.
+- [x] Re-run the entire verification set and perform the architecture review: ownership, boundaries, contract, dependency direction, legacy retirement, and complexity closure.
+- [x] Update OpenSpec task checkboxes and Aegis checkpoint/evidence/drift records, then commit final scoped fixes/evidence with repository-history style.
 
 ## Risks And Rewind Rules
 

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -1,0 +1,340 @@
+# Redesign Daily Push Mechanism Implementation Plan
+
+## Goal
+
+Implement the approved `redesign-daily-push-mechanism` OpenSpec change so each Discord server can configure one independent scheduled push for each of `leetcode.com`, `sheep`, and `0x3f`, while preserving guild language and every legacy LeetCode push through a backed-up transactional migration.
+
+## Architecture
+
+Normalize persistence into guild-wide `server_settings` and source-specific `daily_push_settings`. Route canonical daily-source values through a small shared constants owner. Keep `/config` as the public configuration owner, APScheduler as the job owner, `OjApiClient` as the upstream contract owner, and existing `ui_helpers` functions as the rendering owner. Retire legacy schedule columns after a validated migration; do not add fallback reads or dual writes.
+
+## Tech Stack
+
+Python 3.10+, SQLite, discord.py application commands and components, APScheduler `AsyncIOScheduler`, pytest/pytest-asyncio, Ruff, OpenSpec.
+
+## Baseline / Authority Refs
+
+- `openspec/changes/redesign-daily-push-mechanism/proposal.md`
+- `openspec/changes/redesign-daily-push-mechanism/design.md`
+- `openspec/changes/redesign-daily-push-mechanism/specs/database-layer/spec.md`
+- `openspec/changes/redesign-daily-push-mechanism/specs/daily-schedule/spec.md`
+- `openspec/changes/redesign-daily-push-mechanism/specs/slash-commands/spec.md`
+- `openspec/changes/redesign-daily-push-mechanism/specs/leetcode-client/spec.md`
+- Current capability baselines under `openspec/specs/`
+
+## Compatibility Boundary
+
+- Existing `/config` push updates without `source` continue to target `leetcode.com`.
+- Existing guild language is preserved and remains shared by all pushes.
+- Every legacy schedule becomes exactly one `leetcode.com` push.
+- Existing manual `/daily` and `/daily_cn` domain calls remain unchanged.
+- Existing LeetCode single-problem scheduled output remains unchanged.
+- No runtime fallback reads or writes legacy push columns after migration.
+
+## Verification
+
+```bash
+uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py
+uv run pytest tests/test_daily_source_delivery.py tests/test_daily_payload_reuse.py
+uv run pytest tests/test_schedule_manager_cog.py
+uv run pytest tests/test_config_command.py tests/test_interaction_handler.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+openspec validate redesign-daily-push-mechanism --strict
+python3 /home/usaya/.codex/aegis/scripts/aegis-workspace.py check --root .
+```
+
+Expected final result: all commands exit `0`; pytest reports no failures; OpenSpec reports the change valid; the Aegis workspace check passes.
+
+## Plan Basis
+
+- Requirement status: approved by the user after written-spec review.
+- Facts: current persistence and scheduler identities are server-only; upstream daily data accepts canonical `source` and may contain multiple problems.
+- Assumptions: the bot remains a single-process runtime with MemoryJobStore; no distributed delivery guarantee is required.
+- Unknowns to resolve through RED tests: exact legacy backup filename assertions and Discord command callback invocation mechanics.
+
+## Change Necessity
+
+- User-visible need: independently configure and deliver three daily sources.
+- No-change option: impossible because the current primary key and scheduler job ID permit only one push per server.
+- Minimum change boundary: persistence/schema assets, `/config`, reset/removal interactions, scheduler, API source query, scheduled rendering, locales, tests, and README.
+- Decision: `code-change`.
+
+## Existence Check
+
+- Proposed surface: `src/bot/utils/daily_sources.py`.
+- Reuse candidates: `ui_constants.py`, `config.py`, or duplicate literals.
+- Why insufficient: source identity is a domain contract shared by persistence, API, scheduler, commands, and UI rather than UI-only or process configuration.
+- Creation proof: a single constants/validation owner prevents five modules from drifting on canonical values and default mapping.
+- Retirement impact: no old owner exists; scattered source literals introduced during the change are forbidden.
+- Decision: `add-with-proof`.
+
+## Architecture Integrity Lens
+
+- Invariant: at most one push per `(server_id, supported_source)` and at most three per server.
+- Canonical owners: `server_settings` for language; `daily_push_settings` for delivery; `daily_sources.py` for source identity.
+- Responsibility overlap: none after legacy push columns are retired.
+- Higher-level simplification: scheduler and `/config` consume the same push record shape returned by the database.
+- Retirement: legacy table representation is dropped only after backup and migration validation.
+- Verdict: normalized owner split is coherent; proceed.
+
+## Plan-Time Complexity Check
+
+- `src/bot/utils/ui_helpers.py`: 1,145 lines, strong pressure. Modify only existing daily/settings helpers; do not add configuration orchestration.
+- `src/bot/cogs/slash_commands_cog.py`: 694 lines, moderate pressure. Keep public callback wiring in place but extract small private parsing/rendering helpers within the class or a focused helper module only if the touched block exceeds roughly 80 cohesive lines.
+- `src/bot/utils/database.py`: 402 lines, acceptable. Keep migration and settings CRUD together because they share the SQLite contract.
+- `src/bot/cogs/schedule_manager_cog.py`: 241 lines, acceptable and correct owner for job identity/lifecycle.
+- Recommendation: add `daily_sources.py`; edit other owners in place; create focused test files instead of growing unrelated large suites.
+
+## Execution Readiness View
+
+- Intent Lock: three supported pushes, one per source, independent delivery fields, shared language.
+- Scope Fence: no manual `/daily_extra`, arbitrary sources, distributed idempotency, or upstream calendar duplication.
+- Baseline Lock: approved OpenSpec change at commit `eda46ec`.
+- Owner constraints: no dual persistence owners; no caller-side legacy fallback.
+- Compatibility: source-less `/config` means LeetCode; manual domain calls remain.
+- Retirement: backup, copy, validate, drop legacy representation in one transaction.
+- Task batches: constants/schema; DB migration/CRUD; API/rendering; scheduler; commands/interactions; locales/docs/spec checklist; full verification.
+- Test obligations: RED before each behavior slice, targeted GREEN, then full suite and lint.
+- Drift rule: return to design if a fourth source, duplicate same-source push, persistent history, or new public command becomes necessary.
+- Completion evidence: fresh command output for all verification commands.
+
+## Task 1: Establish Canonical Source Identity And Normalized Schema Assets
+
+**Files:**
+
+- Create `src/bot/utils/daily_sources.py`
+- Modify `data/init_db_schema.sql`
+- Modify `data/cleanup_runtime_db.py`
+- Modify `tests/test_database_schema_assets.py`
+
+**Why:** The database must enforce the supported-source set and per-source uniqueness before higher layers can depend on it.
+
+**Impact / Compatibility:** New databases use normalized tables. The cleanup utility must preserve both normalized databases and legacy schedules as `leetcode.com`.
+
+**Verification:** `uv run pytest tests/test_database_schema_assets.py`
+
+- [ ] Write failing schema tests asserting `daily_push_settings`, composite primary key, source `CHECK`, foreign key cascade, updated target tables, normalized cleanup copies, and legacy cleanup conversion.
+- [ ] Run the verification command and confirm failures reference missing `daily_push_settings`/legacy conversion.
+- [ ] Add `DEFAULT_DAILY_PUSH_SOURCE = "leetcode.com"`, immutable supported-source values, choice labels, and a validation helper; update init SQL and cleanup rebuild logic to use the approved schema and legacy conversion.
+- [ ] Re-run the verification command and confirm all schema asset tests pass.
+- [ ] Commit with `🧪 test(db): define normalized push schema assets` or the closest repository-history style.
+
+## Task 2: Implement Backed-Up Transactional Migration And Settings CRUD
+
+**Files:**
+
+- Modify `src/bot/utils/database.py`
+- Create `tests/test_settings_database.py`
+- Modify `tests/test_bootstrap_and_paths.py` only if path-safe backup behavior needs coverage there
+
+**Why:** Runtime startup must safely migrate real legacy data and expose source-specific CRUD as the sole settings contract.
+
+**Impact / Compatibility:** Replace the old combined getters/setters with guild and push operations while retaining `get_server_settings(server_id)` as the locale-compatible guild lookup. Existing callers migrate in later tasks within the same branch.
+
+**Target API:**
+
+```python
+get_server_settings(server_id) -> dict | None
+set_server_language(server_id, language) -> bool
+get_daily_push(server_id, source) -> dict | None
+get_daily_pushes(server_id) -> list[dict]
+get_all_daily_pushes() -> list[dict]
+set_daily_push(server_id, source, channel_id, role_id=None,
+               post_time="00:00", timezone="UTC") -> bool
+delete_daily_push(server_id, source) -> bool
+delete_server_settings(server_id) -> bool
+```
+
+`get_all_daily_pushes()` returns push fields plus joined `language`.
+
+**Verification:** `uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py tests/test_bootstrap_and_paths.py`
+
+- [ ] Write failing tests for new-schema CRUD isolation, default language creation, unsupported source rejection, cascade reset, legacy backup creation, exact legacy-to-LeetCode copy, idempotent restart, and transaction rollback under injected validation failure.
+- [ ] Run the verification command and confirm failures arise from missing migration/CRUD behavior.
+- [ ] Centralize settings connections with `PRAGMA foreign_keys = ON`; implement schema detection, SQLite backup, transactional table rebuild and validation, and the target CRUD API using parameterized queries.
+- [ ] Re-run the verification command and confirm migration and CRUD tests pass without changing LLM cache behavior.
+- [ ] Commit with `✨ feat(db): normalize daily push settings`.
+
+## Task 3: Add Source-Aware Daily API Access And Scheduled Rendering
+
+**Files:**
+
+- Modify `src/bot/api_client.py`
+- Modify `src/bot/utils/ui_helpers.py`
+- Modify `tests/test_daily_payload_reuse.py`
+- Create `tests/test_daily_source_delivery.py`
+
+**Why:** Sheep and 0x3f must be requested with `source`, preserve multiple ordered problems, and render through existing overview controls.
+
+**Impact / Compatibility:** Existing `get_daily(domain, date)` and manual domain helpers stay valid. New source calls must not send `domain`. Payload cache keys must distinguish canonical source from domain aliases.
+
+**Target API:**
+
+```python
+async def get_daily(
+    self,
+    domain: str = "com",
+    date: str | None = None,
+    *,
+    source: str | None = None,
+) -> dict | None:
+    ...
+
+async def send_daily_challenge(
+    *,
+    bot,
+    interaction=None,
+    channel_id=None,
+    role_id=None,
+    guild_locale=None,
+    daily_source="leetcode.com",
+):
+    ...
+```
+
+**Verification:** `uv run pytest tests/test_daily_source_delivery.py tests/test_daily_payload_reuse.py`
+
+- [ ] Write failing tests proving `source=sheep|0x3f` request params, domain compatibility, envelope preservation, cache-key isolation, single-problem existing rendering, multi-problem overview/view reuse, role mention, and distinguishable 404 handling.
+- [ ] Run the verification command and confirm the new source/rendering tests fail for the expected missing arguments and single-problem assumption.
+- [ ] Extend `OjApiClient.get_daily()` and the existing daily payload/send helpers; reuse `create_problems_overview_embed()` and `create_problems_overview_view()` without adding new UI protocols.
+- [ ] Re-run the verification command and confirm both new and existing daily payload tests pass.
+- [ ] Commit with `✨ feat(daily): support source-aware push rendering`.
+
+## Task 4: Make Scheduler Jobs Independent By Server And Source
+
+**Files:**
+
+- Modify `src/bot/cogs/schedule_manager_cog.py`
+- Modify `src/bot/app.py`
+- Modify `tests/test_schedule_manager_cog.py`
+
+**Why:** Persistence can own three rows only if job identity, rescheduling, delivery guards, logs, and failures are source-scoped.
+
+**Impact / Compatibility:** The app-level reschedule helper accepts an optional source. Omitting source reschedules all pushes for the server, preserving reset behavior; source-specific configuration passes the selected source.
+
+**Target signatures:**
+
+```python
+async def reschedule_daily_challenge(server_id: int | None = None,
+                                     source: str | None = None): ...
+async def send_daily_challenge_job(server_id: int, source: str,
+                                   channel_id: int, role_id: int | None,
+                                   timezone_str: str): ...
+```
+
+Job IDs use a deterministic helper such as `daily_challenge:{server_id}:{source}`. Delivery keys are `(server_id, channel_id, source, date)`.
+
+**Verification:** `uv run pytest tests/test_schedule_manager_cog.py tests/test_daily_source_delivery.py`
+
+- [ ] Extend failing scheduler tests for three startup jobs, deterministic IDs, targeted reschedule/removal, peer-source survival after invalid config, source-scoped deduplication, 404 skip, and source forwarding.
+- [ ] Run the verification command and confirm failures show server-only job identity and hard-coded `com` delivery.
+- [ ] Refactor job creation/rescheduling around daily push records, pass canonical source through delivery, and treat upstream not-found as expected no-delivery while preserving 202 retry and rate-limit handling.
+- [ ] Re-run the verification command and confirm all scheduler tests pass.
+- [ ] Commit with `✨ feat(schedule): isolate jobs by daily source`.
+
+## Task 5: Redesign `/config` Around Global Language And Selected Push
+
+**Files:**
+
+- Modify `src/bot/cogs/slash_commands_cog.py`
+- Modify `src/bot/utils/ui_helpers.py`
+- Create `tests/test_config_command.py`
+
+**Why:** Administrators need one backward-compatible command to list, create, partially update, and request removal of independent source pushes.
+
+**Impact / Compatibility:** No-source push edits map to `leetcode.com`. Language-only updates need no channel. New pushes require channel. `remove` requires explicit source. Existing permission, time, timezone, and role validation remains.
+
+**Command additions:**
+
+```python
+source: str | None = None
+remove: bool = False
+```
+
+Use fixed `app_commands.Choice` values from the canonical source owner. Keep `reset` whole-guild. Settings display passes one language value and ordered push records to a revised settings embed helper.
+
+**Verification:** `uv run pytest tests/test_config_command.py`
+
+- [ ] Write failing callback/helper tests for list, legacy default source, each source create, partial update, language-only update, first-source channel requirement, role conflict, remove-without-source rejection, remove/reset conflict, and custom-ID length.
+- [ ] Run the verification command and confirm failures reflect the old combined row model.
+- [ ] Refactor `/config` input classification, persistence calls, source-specific reschedule calls, and settings rendering while keeping changes out of unrelated slash commands.
+- [ ] Re-run the verification command and confirm all command tests pass.
+- [ ] Commit with `✨ feat(config): manage source-specific pushes`.
+
+## Task 6: Add Confirmed Source Removal And Preserve Whole-Guild Reset
+
+**Files:**
+
+- Modify `src/bot/cogs/interaction_handler_cog.py`
+- Modify `tests/test_interaction_handler.py`
+
+**Why:** Destructive source removal needs the same requester, permission, guild, and expiry protections as reset without weakening reset semantics.
+
+**Impact / Compatibility:** Existing `config_reset_{confirm|cancel}|guild|user|expiry` IDs remain accepted. New source-removal IDs contain canonical source and remain under 100 characters. Confirming removal deletes and reschedules only one source.
+
+**Verification:** `uv run pytest tests/test_interaction_handler.py tests/test_config_command.py`
+
+- [ ] Add failing tests for valid confirm/cancel, malformed IDs, wrong guild/user, expiry, permission denial, exact source deletion, peer-source preservation, legacy reset routing, and maximum custom-ID length.
+- [ ] Run the verification command and confirm source-removal tests fail while existing interaction tests establish the baseline.
+- [ ] Implement a focused `_handle_config_remove()` route or a shared confirmation parser without weakening validation; pass source to the reschedule helper.
+- [ ] Re-run the verification command and confirm new removal and existing reset tests pass.
+- [ ] Commit with `✨ feat(config): confirm source push removal`.
+
+## Task 7: Localize And Document The New Configuration Workflow
+
+**Files:**
+
+- Modify `src/bot/i18n/locales/zh-TW.json`
+- Modify `src/bot/i18n/locales/en-US.json`
+- Modify `src/bot/i18n/locales/zh-CN.json`
+- Modify `README.md`
+- Add `openspec/changes/redesign-daily-push-mechanism/tasks.md`
+- Modify locale/spec tests if existing validation requires explicit assertions
+
+**Why:** Every new option, validation error, settings section, and confirmation must remain usable in all supported locales; operators need migration and configuration examples.
+
+**Impact / Compatibility:** Existing localization keys remain. Add source names, independent push labels, no-source removal error, source removal confirmation/success, and unavailable-day logging only where user-facing text exists.
+
+**Verification:** `uv run pytest tests/test_source_layout_phase56.py tests/test_config_command.py && openspec validate redesign-daily-push-mechanism --strict`
+
+- [ ] Add or update failing locale-parity and documentation assertions for the new command keys/examples.
+- [ ] Run the verification command and confirm missing keys/checklist entries fail.
+- [ ] Add equivalent keys in all locale JSON files, update README command table/examples/migration note, and mark completed OpenSpec tasks only as implementation evidence is produced.
+- [ ] Re-run the verification command and confirm locale tests and strict OpenSpec validation pass.
+- [ ] Commit with `📝 docs(config): document multi-source daily pushes`.
+
+## Task 8: Full Regression, Architecture Review, And Completion Evidence
+
+**Files:**
+
+- Modify only files required to fix verified regressions within the approved scope
+- Update `docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/` through the workspace helper
+
+**Why:** Cross-module schema and scheduler changes need fresh full-suite evidence and explicit retirement verification.
+
+**Verification:** Run every command in the plan header.
+
+- [ ] Run targeted test groups once more and record exact results.
+- [ ] Run full pytest, Ruff check, Ruff format check, strict OpenSpec validation, lingering-reference searches for legacy push columns and server-only job IDs, and Aegis workspace check.
+- [ ] Fix only failures caused by this change, re-running the narrow failing command after each fix.
+- [ ] Re-run the entire verification set and perform the architecture review: ownership, boundaries, contract, dependency direction, legacy retirement, and complexity closure.
+- [ ] Update OpenSpec task checkboxes and Aegis checkpoint/evidence/drift records, then commit final scoped fixes/evidence with repository-history style.
+
+## Risks And Rewind Rules
+
+- If migration cannot prove identity/count preservation, stop and retain the legacy table; do not add fallback reads.
+- If Discord option count or custom-ID length exceeds platform limits, simplify confirmation encoding within the existing `/config` owner; do not introduce a second public command without design review.
+- If multi-problem rendering requires a new interaction protocol, stop and verify why the existing problem buttons are insufficient.
+- If baseline tests fail before relevant edits, record them separately and do not attribute them to this change.
+- If any task introduces a fourth source or duplicate same-source push, return to design.
+
+## Retirement
+
+- Retire `channel_id`, `role_id`, `post_time`, and `timezone` from `server_settings` after validated copy.
+- Retire `set_server_settings()` and `get_all_servers()` once all internal callers use normalized APIs.
+- Retire server-only job ID `daily_challenge_{server_id}` and hard-coded `com` delivery guard keys.
+- Retain source-less `/config` as an external compatibility behavior, not as a persistence fallback.
+- Retain the migration backup as an operator rollback artifact; never read it on the normal runtime path.
+

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -257,11 +257,11 @@ Use fixed `app_commands.Choice` values from the canonical source owner. Keep `re
 
 **Verification:** `uv run pytest tests/test_config_command.py`
 
-- [ ] Write failing callback/helper tests for list, legacy default source, each source create, partial update, language-only update, first-source channel requirement, role conflict, remove-without-source rejection, remove/reset conflict, and custom-ID length.
-- [ ] Run the verification command and confirm failures reflect the old combined row model.
-- [ ] Refactor `/config` input classification, persistence calls, source-specific reschedule calls, and settings rendering while keeping changes out of unrelated slash commands.
-- [ ] Re-run the verification command and confirm all command tests pass.
-- [ ] Commit with `✨ feat(config): manage source-specific pushes`.
+- [x] Write failing callback/helper tests for list, legacy default source, each source create, partial update, language-only update, first-source channel requirement, role conflict, remove-without-source rejection, remove/reset conflict, and custom-ID length.
+- [x] Run the verification command and confirm failures reflect the old combined row model.
+- [x] Refactor `/config` input classification, persistence calls, source-specific reschedule calls, and settings rendering while keeping changes out of unrelated slash commands.
+- [x] Re-run the verification command and confirm all command tests pass.
+- [x] Commit with `✨ feat(config): manage source-specific pushes`.
 
 ## Task 6: Add Confirmed Source Removal And Preserve Whole-Guild Reset
 

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -151,11 +151,11 @@ delete_server_settings(server_id) -> bool
 
 **Verification:** `uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py tests/test_bootstrap_and_paths.py`
 
-- [ ] Write failing tests for new-schema CRUD isolation, default language creation, unsupported source rejection, cascade reset, legacy backup creation, exact legacy-to-LeetCode copy, idempotent restart, and transaction rollback under injected validation failure.
-- [ ] Run the verification command and confirm failures arise from missing migration/CRUD behavior.
-- [ ] Centralize settings connections with `PRAGMA foreign_keys = ON`; implement schema detection, SQLite backup, transactional table rebuild and validation, and the target CRUD API using parameterized queries.
-- [ ] Re-run the verification command and confirm migration and CRUD tests pass without changing LLM cache behavior.
-- [ ] Commit with `✨ feat(db): normalize daily push settings`.
+- [x] Write failing tests for new-schema CRUD isolation, default language creation, unsupported source rejection, cascade reset, legacy backup creation, exact legacy-to-LeetCode copy, idempotent restart, and transaction rollback under injected validation failure.
+- [x] Run the verification command and confirm failures arise from missing migration/CRUD behavior.
+- [x] Centralize settings connections with `PRAGMA foreign_keys = ON`; implement schema detection, SQLite backup, transactional table rebuild and validation, and the target CRUD API using parameterized queries.
+- [x] Re-run the verification command and confirm migration and CRUD tests pass without changing LLM cache behavior.
+- [x] Commit with `✨ feat(db): normalize daily push settings`.
 
 ## Task 3: Add Source-Aware Daily API Access And Scheduled Rendering
 

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -115,11 +115,11 @@ Expected final result: all commands exit `0`; pytest reports no failures; OpenSp
 
 **Verification:** `uv run pytest tests/test_database_schema_assets.py`
 
-- [ ] Write failing schema tests asserting `daily_push_settings`, composite primary key, source `CHECK`, foreign key cascade, updated target tables, normalized cleanup copies, and legacy cleanup conversion.
-- [ ] Run the verification command and confirm failures reference missing `daily_push_settings`/legacy conversion.
-- [ ] Add `DEFAULT_DAILY_PUSH_SOURCE = "leetcode.com"`, immutable supported-source values, choice labels, and a validation helper; update init SQL and cleanup rebuild logic to use the approved schema and legacy conversion.
-- [ ] Re-run the verification command and confirm all schema asset tests pass.
-- [ ] Commit with `🧪 test(db): define normalized push schema assets` or the closest repository-history style.
+- [x] Write failing schema tests asserting `daily_push_settings`, composite primary key, source `CHECK`, foreign key cascade, updated target tables, normalized cleanup copies, and legacy cleanup conversion.
+- [x] Run the verification command and confirm failures reference missing `daily_push_settings`/legacy conversion.
+- [x] Add `DEFAULT_DAILY_PUSH_SOURCE = "leetcode.com"`, immutable supported-source values, choice labels, and a validation helper; update init SQL and cleanup rebuild logic to use the approved schema and legacy conversion.
+- [x] Re-run the verification command and confirm all schema asset tests pass.
+- [x] Commit with `🧪 test(db): define normalized push schema assets` or the closest repository-history style.
 
 ## Task 2: Implement Backed-Up Transactional Migration And Settings CRUD
 
@@ -337,4 +337,3 @@ Use fixed `app_commands.Choice` values from the canonical source owner. Keep `re
 - Retire server-only job ID `daily_challenge_{server_id}` and hard-coded `com` delivery guard keys.
 - Retain source-less `/config` as an external compatibility behavior, not as a persistence fallback.
 - Retain the migration backup as an operator rollback artifact; never read it on the normal runtime path.
-

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -228,11 +228,11 @@ Job IDs use a deterministic helper such as `daily_challenge:{server_id}:{source}
 
 **Verification:** `uv run pytest tests/test_schedule_manager_cog.py tests/test_daily_source_delivery.py`
 
-- [ ] Extend failing scheduler tests for three startup jobs, deterministic IDs, targeted reschedule/removal, peer-source survival after invalid config, source-scoped deduplication, 404 skip, and source forwarding.
-- [ ] Run the verification command and confirm failures show server-only job identity and hard-coded `com` delivery.
-- [ ] Refactor job creation/rescheduling around daily push records, pass canonical source through delivery, and treat upstream not-found as expected no-delivery while preserving 202 retry and rate-limit handling.
-- [ ] Re-run the verification command and confirm all scheduler tests pass.
-- [ ] Commit with `✨ feat(schedule): isolate jobs by daily source`.
+- [x] Extend failing scheduler tests for three startup jobs, deterministic IDs, targeted reschedule/removal, peer-source survival after invalid config, source-scoped deduplication, 404 skip, and source forwarding.
+- [x] Run the verification command and confirm failures show server-only job identity and hard-coded `com` delivery.
+- [x] Refactor job creation/rescheduling around daily push records, pass canonical source through delivery, and treat upstream not-found as expected no-delivery while preserving 202 retry and rate-limit handling.
+- [x] Re-run the verification command and confirm all scheduler tests pass.
+- [x] Commit with `✨ feat(schedule): isolate jobs by daily source`.
 
 ## Task 5: Redesign `/config` Around Global Language And Selected Push
 

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -196,11 +196,11 @@ async def send_daily_challenge(
 
 **Verification:** `uv run pytest tests/test_daily_source_delivery.py tests/test_daily_payload_reuse.py`
 
-- [ ] Write failing tests proving `source=sheep|0x3f` request params, domain compatibility, envelope preservation, cache-key isolation, single-problem existing rendering, multi-problem overview/view reuse, role mention, and distinguishable 404 handling.
-- [ ] Run the verification command and confirm the new source/rendering tests fail for the expected missing arguments and single-problem assumption.
-- [ ] Extend `OjApiClient.get_daily()` and the existing daily payload/send helpers; reuse `create_problems_overview_embed()` and `create_problems_overview_view()` without adding new UI protocols.
-- [ ] Re-run the verification command and confirm both new and existing daily payload tests pass.
-- [ ] Commit with `✨ feat(daily): support source-aware push rendering`.
+- [x] Write failing tests proving `source=sheep|0x3f` request params, domain compatibility, envelope preservation, cache-key isolation, single-problem existing rendering, multi-problem overview/view reuse, role mention, and distinguishable 404 handling.
+- [x] Run the verification command and confirm the new source/rendering tests fail for the expected missing arguments and single-problem assumption.
+- [x] Extend `OjApiClient.get_daily()` and the existing daily payload/send helpers; reuse `create_problems_overview_embed()` and `create_problems_overview_view()` without adding new UI protocols.
+- [x] Re-run the verification command and confirm both new and existing daily payload tests pass.
+- [x] Commit with `✨ feat(daily): support source-aware push rendering`.
 
 ## Task 4: Make Scheduler Jobs Independent By Server And Source
 

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -299,11 +299,11 @@ Use fixed `app_commands.Choice` values from the canonical source owner. Keep `re
 
 **Verification:** `uv run pytest tests/test_source_layout_phase56.py tests/test_config_command.py && openspec validate redesign-daily-push-mechanism --strict`
 
-- [ ] Add or update failing locale-parity and documentation assertions for the new command keys/examples.
-- [ ] Run the verification command and confirm missing keys/checklist entries fail.
-- [ ] Add equivalent keys in all locale JSON files, update README command table/examples/migration note, and mark completed OpenSpec tasks only as implementation evidence is produced.
-- [ ] Re-run the verification command and confirm locale tests and strict OpenSpec validation pass.
-- [ ] Commit with `📝 docs(config): document multi-source daily pushes`.
+- [x] Add or update failing locale-parity and documentation assertions for the new command keys/examples.
+- [x] Run the verification command and confirm missing keys/checklist entries fail.
+- [x] Add equivalent keys in all locale JSON files, update README command table/examples/migration note, and mark completed OpenSpec tasks only as implementation evidence is produced.
+- [x] Re-run the verification command and confirm locale tests and strict OpenSpec validation pass.
+- [x] Commit with `📝 docs(config): document multi-source daily pushes`.
 
 ## Task 8: Full Regression, Architecture Review, And Completion Evidence
 

--- a/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
+++ b/docs/aegis/plans/2026-07-18-redesign-daily-push-mechanism.md
@@ -276,11 +276,11 @@ Use fixed `app_commands.Choice` values from the canonical source owner. Keep `re
 
 **Verification:** `uv run pytest tests/test_interaction_handler.py tests/test_config_command.py`
 
-- [ ] Add failing tests for valid confirm/cancel, malformed IDs, wrong guild/user, expiry, permission denial, exact source deletion, peer-source preservation, legacy reset routing, and maximum custom-ID length.
-- [ ] Run the verification command and confirm source-removal tests fail while existing interaction tests establish the baseline.
-- [ ] Implement a focused `_handle_config_remove()` route or a shared confirmation parser without weakening validation; pass source to the reschedule helper.
-- [ ] Re-run the verification command and confirm new removal and existing reset tests pass.
-- [ ] Commit with `✨ feat(config): confirm source push removal`.
+- [x] Add failing tests for valid confirm/cancel, malformed IDs, wrong guild/user, expiry, permission denial, exact source deletion, peer-source preservation, legacy reset routing, and maximum custom-ID length.
+- [x] Run the verification command and confirm source-removal tests fail while existing interaction tests establish the baseline.
+- [x] Implement a focused `_handle_config_remove()` route or a shared confirmation parser without weakening validation; pass source to the reschedule helper.
+- [x] Re-run the verification command and confirm new removal and existing reset tests pass.
+- [x] Commit with `✨ feat(config): confirm source push removal`.
 
 ## Task 7: Localize And Document The New Configuration Workflow
 

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md
@@ -1,0 +1,62 @@
+# Redesign daily push mechanism - Intent
+
+## TaskIntentDraft
+
+- Requested outcome: Allow each Discord server to configure one independent scheduled push for each of leetcode.com, sheep, and 0x3f
+- Goal: Allow each Discord server to configure one independent scheduled push for each of leetcode.com, sheep, and 0x3f
+- Success evidence:
+- Schema migration preserves legacy LeetCode pushes; each source schedules and delivers independently; targeted and full tests pass
+- Stop condition: Done when approved OpenSpec requirements are implemented and verified; otherwise stop as blocked, needs-verification, or scope-exceeded
+- Non-goals:
+- Multiple pushes for the same source
+- Persistent cross-process delivery history
+- Changes to upstream source availability rules
+- Scope: Database schema and migration, config command behavior, APScheduler job ownership, daily API source selection, multi-problem scheduled rendering, localization, tests, and docs
+- Change kinds:
+- architecture-contract-migration
+- Risk hints:
+- Persistent SQLite migration and compatibility of existing /config behavior
+
+## BaselineReadSetHint
+
+- openspec/specs/database-layer/spec.md
+- openspec/specs/daily-schedule/spec.md
+- openspec/specs/slash-commands/spec.md
+- openspec/specs/leetcode-client/spec.md
+
+## BaselineUsageDraft
+
+- Required baseline refs:
+- openspec/specs/database-layer/spec.md
+- openspec/specs/daily-schedule/spec.md
+- openspec/specs/slash-commands/spec.md
+- openspec/specs/leetcode-client/spec.md
+- Acknowledged before plan:
+- none
+- Cited in plan:
+- none
+- Missing refs:
+- openspec/specs/database-layer/spec.md
+- openspec/specs/daily-schedule/spec.md
+- openspec/specs/slash-commands/spec.md
+- openspec/specs/leetcode-client/spec.md
+- Advisory decision: needs-baseline-readback
+
+## ImpactStatementDraft
+
+- Compatibility boundary: Existing /config invocations without source continue to manage leetcode.com and legacy settings migrate without data loss
+- Affected layers:
+- persistence
+- Discord command surface
+- scheduler
+- API client and UI rendering
+- Owners:
+- SettingsDatabaseManager; SlashCommandsCog; ScheduleManagerCog; OjApiClient; ui_helpers
+- Invariants:
+- At most one push per server and supported source, with at most three pushes per server
+- Non-goals:
+- Multiple pushes for the same source
+- Persistent cross-process delivery history
+- Changes to upstream source availability rules
+
+These records are Method Pack drafts / hints, not authoritative runtime decisions.

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -29,3 +29,24 @@
 - aegis-workspace.py check --root .: passed
 - Blocked on: User review of written specification
 - Next step: After approval, use writing-plans to create the implementation plan
+
+## DriftCheckDraft
+
+- Scope status: Task 1 changed only canonical source identity and schema assets
+- Compatibility status: Legacy cleanup conversion maps old schedules to leetcode.com
+- Retirement status: No runtime legacy fallback added; runtime migration remains Task 2
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Implement Task 2 runtime migration and normalized CRUD
+- Active slice: Task 2 database migration and CRUD
+- Completed todos:
+- Task 1 canonical sources and normalized schema assets
+- Evidence refs:
+- tests/test_database_schema_assets.py: pass
+- targeted Ruff check and format: pass
+- Blocked on: none
+- Next step: Write RED tests in tests/test_settings_database.py

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -1,0 +1,31 @@
+# Redesign daily push mechanism - Checkpoint
+
+- Task ID: 2026-07-18-redesign-daily-push-mechanism
+- Current todo: Write and validate the approved OpenSpec design
+- Active slice: Specification
+- Blocked on: none
+- Next step: Create proposal, design, and delta specs; validate and request written-spec review
+
+## DriftCheckDraft
+
+- Scope status: Specification remains within approved schema, config, scheduling, API, UI, tests, and docs scope
+- Compatibility status: Source-less config targets leetcode.com and legacy rows migrate without data loss
+- Retirement status: Legacy push columns have an approved backed-up transactional retirement path
+- New risk signals:
+- none
+- Advisory decision: pause-for-user
+
+## Checkpoint Update
+
+- Current todo: Obtain user review of the written specification
+- Active slice: Written specification review gate
+- Completed todos:
+- Explore current schema, scheduler, API, command, and test owners
+- Confirm one push per source and independent per-push fields
+- Approve normalized schema and explicit legacy migration
+- Write and strictly validate OpenSpec proposal, design, and delta specs
+- Evidence refs:
+- openspec validate redesign-daily-push-mechanism --strict: valid
+- aegis-workspace.py check --root .: passed
+- Blocked on: User review of written specification
+- Next step: After approval, use writing-plans to create the implementation plan

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -156,3 +156,25 @@
 - targeted Ruff check and format: pass
 - Blocked on: none
 - Next step: Add locale parity and README assertions, then update all supported locales and configuration docs
+
+## DriftCheckDraft
+
+- Scope status: Task 7 changed only supported locale resources, README usage/migration documentation, and focused documentation tests
+- Compatibility status: Existing reset and configuration keys remain; new source-specific keys are present in all three locales
+- Retirement status: README documents backed-up one-way migration to leetcode.com rather than runtime fallback behavior
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Run Task 8 full regression and retirement verification
+- Active slice: Task 8 completion evidence
+- Completed todos:
+- Task 7 locale parity, README multi-source workflow, and migration documentation
+- Evidence refs:
+- tests/test_source_layout_phase56.py, tests/test_config_command.py, and tests/test_interaction_handler.py: pass
+- openspec validate redesign-daily-push-mechanism --strict: valid
+- targeted Ruff check and format: pass
+- Blocked on: none
+- Next step: Load verification-before-completion instructions and run every final verification command

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -114,3 +114,24 @@
 - targeted Ruff check and format: pass
 - Blocked on: none
 - Next step: Inspect config callback and write RED command tests for global language plus selected push
+
+## DriftCheckDraft
+
+- Scope status: Task 5 stayed within the config callback, existing settings embed owner, normalized CRUD example, and focused command tests
+- Compatibility status: Source-less push fields target leetcode.com; language-only updates do not require or create a push
+- Retirement status: All Python runtime and example calls to combined legacy settings CRUD are removed
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Implement Task 6 confirmed source removal
+- Active slice: Task 6 interaction routing and security checks
+- Completed todos:
+- Task 5 fixed source choices, source-specific create/update/removal request, global language, and multi-push settings display
+- Evidence refs:
+- tests/test_config_command.py, tests/test_settings_database.py, and tests/test_schedule_manager_cog.py: pass
+- targeted Ruff check and format: pass
+- Blocked on: none
+- Next step: Write RED component tests for source removal and legacy reset preservation

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -93,3 +93,24 @@
 - targeted Ruff check and format: pass
 - Blocked on: none
 - Next step: Write RED scheduler tests for per-source job identity and isolation
+
+## DriftCheckDraft
+
+- Scope status: Task 4 stayed within scheduler ownership, the app reschedule adapter, and scheduler tests
+- Compatibility status: Existing server-only reschedule calls rebuild all server pushes; callers may opt into targeted source rescheduling
+- Retirement status: Server-only job IDs, combined settings reads, and hard-coded com delivery keys were removed
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Implement Task 5 source-specific config command
+- Active slice: Task 5 configuration and settings display
+- Completed todos:
+- Task 4 deterministic per-source jobs, targeted rescheduling, source-scoped delivery guards, and expected not-found handling
+- Evidence refs:
+- tests/test_schedule_manager_cog.py and tests/test_daily_source_delivery.py: pass
+- targeted Ruff check and format: pass
+- Blocked on: none
+- Next step: Inspect config callback and write RED command tests for global language plus selected push

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -50,3 +50,25 @@
 - targeted Ruff check and format: pass
 - Blocked on: none
 - Next step: Write RED tests in tests/test_settings_database.py
+
+## DriftCheckDraft
+
+- Scope status: Task 2 stayed within SettingsDatabaseManager and focused database tests
+- Compatibility status: Legacy rows preserve language and delivery fields as leetcode.com; source-less command compatibility remains for later task
+- Retirement status: Legacy table is dropped only after backup and validation; combined CRUD removed from owner, callers pending
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Implement Task 3 source-aware API and scheduled rendering
+- Active slice: Task 3 daily API and rendering
+- Completed todos:
+- Task 1 canonical sources and schema assets
+- Task 2 backed-up migration and normalized CRUD
+- Evidence refs:
+- settings/schema/path targeted pytest: pass
+- targeted Ruff: pass
+- Blocked on: none
+- Next step: Write RED daily source request and multi-problem delivery tests

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -72,3 +72,24 @@
 - targeted Ruff: pass
 - Blocked on: none
 - Next step: Write RED daily source request and multi-problem delivery tests
+
+## DriftCheckDraft
+
+- Scope status: Task 3 stayed within the API client, existing daily rendering owner, and focused tests
+- Compatibility status: Manual domain calls remain unchanged; source requests use canonical source identity and source-scoped cache keys
+- Retirement status: No alternate rendering protocol or API fallback was added
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Implement Task 4 source-scoped scheduler jobs
+- Active slice: Task 4 scheduler isolation
+- Completed todos:
+- Task 3 source-aware API access and scheduled single/multi-problem rendering
+- Evidence refs:
+- tests/test_daily_source_delivery.py and tests/test_daily_payload_reuse.py: pass
+- targeted Ruff check and format: pass
+- Blocked on: none
+- Next step: Write RED scheduler tests for per-source job identity and isolation

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -178,3 +178,25 @@
 - targeted Ruff check and format: pass
 - Blocked on: none
 - Next step: Load verification-before-completion instructions and run every final verification command
+
+## Checkpoint Update
+
+- Current todo: Complete final evidence and branch handoff
+- Active slice: Task 8 completion evidence
+- Completed todos:
+- Tasks 1-7 implementation and targeted verification
+- Fresh full pytest, Ruff, strict OpenSpec, retirement scan, ADR backfill, and baseline sync closure
+- Evidence refs:
+- evidence-bundle-draft-final-full-verification-green.json
+- docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md
+- Blocked on: none
+- Next step: Commit final evidence and present branch handoff options
+
+## DriftCheckDraft
+
+- Scope status: Implementation remains within the approved three-source schema, scheduler, config, rendering, localization, tests, and documentation scope.
+- Compatibility status: Source-less config still targets leetcode.com; manual domain calls and legacy reset IDs remain supported; legacy rows are backed up and migrated without dual reads.
+- Retirement status: Combined CRUD, live legacy delivery columns, server-only job IDs, and hard-coded com delivery keys are retired; legacy reads are isolated to the one-way migration owner.
+- New risk signals:
+- ui_helpers.py remains a 1225-line pressure point; future UI-domain extraction is recommended.
+- Advisory decision: continue

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md
@@ -135,3 +135,24 @@
 - targeted Ruff check and format: pass
 - Blocked on: none
 - Next step: Write RED component tests for source removal and legacy reset preservation
+
+## DriftCheckDraft
+
+- Scope status: Task 6 stayed within interaction routing and its focused regression suite
+- Compatibility status: Existing four-part reset IDs and whole-guild reset action remain unchanged
+- Retirement status: Source removal has a distinct five-part route and cannot invoke whole-guild deletion
+- New risk signals:
+- none
+- Advisory decision: continue
+
+## Checkpoint Update
+
+- Current todo: Implement Task 7 localization and documentation
+- Active slice: Task 7 locales, README, and strict spec validation
+- Completed todos:
+- Task 6 secure source removal confirmation with targeted deletion/rescheduling and legacy reset preservation
+- Evidence refs:
+- tests/test_interaction_handler.py and tests/test_config_command.py: pass
+- targeted Ruff check and format: pass
+- Blocked on: none
+- Next step: Add locale parity and README assertions, then update all supported locales and configuration docs

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -65,3 +65,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_interaction_handler.py tests/test_config_command.py; targeted Ruff
 - Summary: Source removal confirm/cancel and security guards pass; exact source deletion and targeted rescheduling are verified; legacy whole-guild reset routing remains valid
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task7-locales-docs-green
+- Type: command
+- Source: uv run pytest tests/test_source_layout_phase56.py tests/test_config_command.py tests/test_interaction_handler.py; openspec validate redesign-daily-push-mechanism --strict; targeted Ruff
+- Summary: New user-facing keys exist in all supported locales, README documents independent pushes and backed-up migration, and strict OpenSpec validation passes
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -41,3 +41,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_daily_source_delivery.py tests/test_daily_payload_reuse.py; targeted Ruff
 - Summary: Source API params, domain compatibility, cache isolation, single/multi-problem rendering, role mention, and source-not-found propagation pass
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task4-source-scoped-scheduler-green
+- Type: command
+- Source: uv run pytest tests/test_schedule_manager_cog.py tests/test_daily_source_delivery.py; targeted Ruff
+- Summary: Startup jobs, job identity, targeted and whole-server rescheduling, source-scoped deduplication, retry, not-found skip, and source forwarding pass
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -33,3 +33,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py tests/test_bootstrap_and_paths.py; targeted Ruff
 - Summary: Runtime backup/migration/rollback/idempotency and normalized settings CRUD tests pass; targeted lint and format pass
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task3-daily-source-delivery-green
+- Type: command
+- Source: uv run pytest tests/test_daily_source_delivery.py tests/test_daily_payload_reuse.py; targeted Ruff
+- Summary: Source API params, domain compatibility, cache isolation, single/multi-problem rendering, role mention, and source-not-found propagation pass
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -1,0 +1,19 @@
+# Redesign daily push mechanism - Evidence
+
+No evidence has been recorded yet.
+
+## EvidenceBundleDraft
+
+- Artifact key: openspec-strict-validation
+- Type: command
+- Source: openspec validate redesign-daily-push-mechanism --strict
+- Summary: OpenSpec change is valid
+- Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: aegis-workspace-check
+- Type: command
+- Source: aegis-workspace.py check --root .
+- Summary: Aegis workspace structure is valid
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -25,3 +25,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_database_schema_assets.py; ruff targeted checks
 - Summary: Normalized schema, constraints, and legacy cleanup conversion tests pass; targeted lint and format pass
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task2-database-green
+- Type: command
+- Source: uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py tests/test_bootstrap_and_paths.py; targeted Ruff
+- Summary: Runtime backup/migration/rollback/idempotency and normalized settings CRUD tests pass; targeted lint and format pass
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -49,3 +49,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_schedule_manager_cog.py tests/test_daily_source_delivery.py; targeted Ruff
 - Summary: Startup jobs, job identity, targeted and whole-server rescheduling, source-scoped deduplication, retry, not-found skip, and source forwarding pass
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task5-source-config-green
+- Type: command
+- Source: uv run pytest tests/test_config_command.py tests/test_settings_database.py tests/test_schedule_manager_cog.py; targeted Ruff
+- Summary: Fixed source choices, LeetCode default updates, three-source creation, partial updates, global language, removal confirmation IDs, and multi-push display pass
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -17,3 +17,11 @@ No evidence has been recorded yet.
 - Source: aegis-workspace.py check --root .
 - Summary: Aegis workspace structure is valid
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task1-schema-assets-green
+- Type: command
+- Source: uv run pytest tests/test_database_schema_assets.py; ruff targeted checks
+- Summary: Normalized schema, constraints, and legacy cleanup conversion tests pass; targeted lint and format pass
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -57,3 +57,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_config_command.py tests/test_settings_database.py tests/test_schedule_manager_cog.py; targeted Ruff
 - Summary: Fixed source choices, LeetCode default updates, three-source creation, partial updates, global language, removal confirmation IDs, and multi-push display pass
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: task6-source-removal-green
+- Type: command
+- Source: uv run pytest tests/test_interaction_handler.py tests/test_config_command.py; targeted Ruff
+- Summary: Source removal confirm/cancel and security guards pass; exact source deletion and targeted rescheduling are verified; legacy whole-guild reset routing remains valid
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/90-evidence.md
@@ -73,3 +73,11 @@ No evidence has been recorded yet.
 - Source: uv run pytest tests/test_source_layout_phase56.py tests/test_config_command.py tests/test_interaction_handler.py; openspec validate redesign-daily-push-mechanism --strict; targeted Ruff
 - Summary: New user-facing keys exist in all supported locales, README documents independent pushes and backed-up migration, and strict OpenSpec validation passes
 - Verifier: Codex
+
+## EvidenceBundleDraft
+
+- Artifact key: final-full-verification-green
+- Type: command
+- Source: targeted pytest; full pytest; ruff check .; ruff format --check .; openspec strict; retirement rg
+- Summary: All targeted and full regression commands exited 0; Ruff and strict OpenSpec passed; no combined settings CRUD or server-only scheduler job IDs remain; legacy column access is isolated to the one-way migration owner.
+- Verifier: Codex

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/99-reflection.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/99-reflection.md
@@ -1,0 +1,5 @@
+# Redesign daily push mechanism - Reflection
+
+Completion reflection has not been recorded yet.
+
+Method Pack output does not grant completion authority.

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/99-reflection.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/99-reflection.md
@@ -1,5 +1,36 @@
 # Redesign daily push mechanism - Reflection
 
-Completion reflection has not been recorded yet.
+## Outcome
+
+- Normalized guild language and source-specific delivery ownership are implemented for `leetcode.com`, `sheep`, and `0x3f`.
+- Legacy schedules migrate transactionally to `leetcode.com` after a timestamped backup and no normal runtime fallback remains.
+- Scheduler, configuration, removal confirmation, rendering, localization, and documentation carry canonical source identity end to end.
+
+## Architecture Review
+
+- Ownership integrity: `server_settings` owns guild language, `daily_push_settings` owns delivery, and `daily_sources.py` owns source identity.
+- Module boundaries: database, scheduler, API, commands, interactions, and UI remain in their existing owners; the app helper is wiring only.
+- Contract changes: normalized schema, source-aware API, job IDs, `/config`, compatibility, and migration behavior are documented in OpenSpec, README, and ADR-0001.
+- Cascade proliferation: source identity is passed through the expected call chain without a second scheduler, command, or rendering protocol.
+- Dependency direction: cogs depend on stable utility contracts; persistence does not depend on command or scheduler layers.
+- Retirement completeness: combined CRUD, legacy delivery columns in the live table, server-only job IDs, and hard-coded `com` delivery guards are removed; legacy column reads exist only in the one-way migration owner.
+- Entropy flow: normalized ownership and a single source validator replace combined state and scattered literals; no fallback or dual-write path was added.
+
+## Complexity Closure
+
+- Budget status: exceeded-and-governed.
+- Governed now: large files received only behavior within their existing owner; overview rendering and confirmation patterns were reused; focused tests were split into new files.
+- Deferred follow-up: `src/bot/utils/ui_helpers.py` is 1225 lines and should eventually be split by UI domain; `slash_commands_cog.py` is 776 lines and should be monitored before adding another major command workflow.
+- Completion impact: complete for the approved redesign; complexity follow-up is non-blocking.
+
+## Risk And Unknowns
+
+- Automated tests mock Discord and the upstream API; no live guild delivery or production database migration was executed in this workspace.
+- Rollback depends on retaining the generated `.pre-push-redesign.bak` file and operator action; the normal runtime intentionally never reads it.
+- A real upstream source can legitimately have no daily payload; scheduler behavior is an expected no-delivery rather than a failure.
+
+## Deeper Cause
+
+The former schema made a guild row own both global language and one schedule. The redesign fixes that ownership mismatch rather than adding three nullable schedule slots or runtime compatibility fallbacks.
 
 Method Pack output does not grant completion authority.

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/baseline-read-set-hint.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/baseline-read-set-hint.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "candidateDocs": [
+    "openspec/specs/database-layer/spec.md",
+    "openspec/specs/daily-schedule/spec.md",
+    "openspec/specs/slash-commands/spec.md",
+    "openspec/specs/leetcode-client/spec.md"
+  ],
+  "whyRelevant": "These existing OpenSpec capabilities own persistence, scheduling, command UX, and daily API access",
+  "missingAuthority": []
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/baseline-usage-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/baseline-usage-draft.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-18-redesign-daily-push-mechanism",
+  "requiredBaselineRefs": [
+    "openspec/specs/database-layer/spec.md",
+    "openspec/specs/daily-schedule/spec.md",
+    "openspec/specs/slash-commands/spec.md",
+    "openspec/specs/leetcode-client/spec.md"
+  ],
+  "deliveredContextRefs": [],
+  "acknowledgedBeforePlanRefs": [],
+  "citedInPlanRefs": [],
+  "missingRefs": [
+    "openspec/specs/database-layer/spec.md",
+    "openspec/specs/daily-schedule/spec.md",
+    "openspec/specs/slash-commands/spec.md",
+    "openspec/specs/leetcode-client/spec.md"
+  ],
+  "decision": "needs-baseline-readback"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
@@ -3,11 +3,14 @@
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
   "taskIntentRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json",
   "baselineRefs": [
-    "openspec/changes/redesign-daily-push-mechanism/design.md"
+    "openspec/changes/redesign-daily-push-mechanism/design.md",
+    "docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md"
   ],
-  "scopeStatus": "Task 2 stayed within SettingsDatabaseManager and focused database tests",
-  "compatStatus": "Legacy rows preserve language and delivery fields as leetcode.com; source-less command compatibility remains for later task",
-  "retirementStatus": "Legacy table is dropped only after backup and validation; combined CRUD removed from owner, callers pending",
-  "newRiskSignals": [],
+  "scopeStatus": "Implementation remains within the approved three-source schema, scheduler, config, rendering, localization, tests, and documentation scope.",
+  "compatStatus": "Source-less config still targets leetcode.com; manual domain calls and legacy reset IDs remain supported; legacy rows are backed up and migrated without dual reads.",
+  "retirementStatus": "Combined CRUD, live legacy delivery columns, server-only job IDs, and hard-coded com delivery keys are retired; legacy reads are isolated to the one-way migration owner.",
+  "newRiskSignals": [
+    "ui_helpers.py remains a 1225-line pressure point; future UI-domain extraction is recommended."
+  ],
   "decision": "continue"
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-18-redesign-daily-push-mechanism",
+  "taskIntentRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json",
+  "baselineRefs": [
+    "openspec/changes/redesign-daily-push-mechanism/design.md"
+  ],
+  "scopeStatus": "Specification remains within approved schema, config, scheduling, API, UI, tests, and docs scope",
+  "compatStatus": "Source-less config targets leetcode.com and legacy rows migrate without data loss",
+  "retirementStatus": "Legacy push columns have an approved backed-up transactional retirement path",
+  "newRiskSignals": [],
+  "decision": "pause-for-user"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
@@ -3,11 +3,11 @@
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
   "taskIntentRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json",
   "baselineRefs": [
-    "openspec/changes/redesign-daily-push-mechanism/design.md"
+    "openspec/changes/redesign-daily-push-mechanism/specs/database-layer/spec.md"
   ],
-  "scopeStatus": "Specification remains within approved schema, config, scheduling, API, UI, tests, and docs scope",
-  "compatStatus": "Source-less config targets leetcode.com and legacy rows migrate without data loss",
-  "retirementStatus": "Legacy push columns have an approved backed-up transactional retirement path",
+  "scopeStatus": "Task 1 changed only canonical source identity and schema assets",
+  "compatStatus": "Legacy cleanup conversion maps old schedules to leetcode.com",
+  "retirementStatus": "No runtime legacy fallback added; runtime migration remains Task 2",
   "newRiskSignals": [],
-  "decision": "pause-for-user"
+  "decision": "continue"
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/drift-check-draft.json
@@ -3,11 +3,11 @@
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
   "taskIntentRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json",
   "baselineRefs": [
-    "openspec/changes/redesign-daily-push-mechanism/specs/database-layer/spec.md"
+    "openspec/changes/redesign-daily-push-mechanism/design.md"
   ],
-  "scopeStatus": "Task 1 changed only canonical source identity and schema assets",
-  "compatStatus": "Legacy cleanup conversion maps old schedules to leetcode.com",
-  "retirementStatus": "No runtime legacy fallback added; runtime migration remains Task 2",
+  "scopeStatus": "Task 2 stayed within SettingsDatabaseManager and focused database tests",
+  "compatStatus": "Legacy rows preserve language and delivery fields as leetcode.com; source-less command compatibility remains for later task",
+  "retirementStatus": "Legacy table is dropped only after backup and validation; combined CRUD removed from owner, callers pending",
   "newRiskSignals": [],
   "decision": "continue"
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "aegis-workspace-check",
+  "type": "command",
+  "source": "aegis-workspace.py check --root .",
+  "summary": "Aegis workspace structure is valid",
+  "verifier": "Codex"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-final-full-verification-green.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-final-full-verification-green.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "final-full-verification-green",
+  "type": "command",
+  "source": "targeted pytest; full pytest; ruff check .; ruff format --check .; openspec strict; retirement rg",
+  "summary": "All targeted and full regression commands exited 0; Ruff and strict OpenSpec passed; no combined settings CRUD or server-only scheduler job IDs remain; legacy column access is isolated to the one-way migration owner.",
+  "verifier": "Codex"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-openspec-strict-validation.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-openspec-strict-validation.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "openspec-strict-validation",
+  "type": "command",
+  "source": "openspec validate redesign-daily-push-mechanism --strict",
+  "summary": "OpenSpec change is valid",
+  "verifier": "Codex"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "task1-schema-assets-green",
+  "type": "command",
+  "source": "uv run pytest tests/test_database_schema_assets.py; ruff targeted checks",
+  "summary": "Normalized schema, constraints, and legacy cleanup conversion tests pass; targeted lint and format pass",
+  "verifier": "Codex"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task2-database-green.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task2-database-green.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "artifactKey": "task2-database-green",
+  "type": "command",
+  "source": "uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py tests/test_bootstrap_and_paths.py; targeted Ruff",
+  "summary": "Runtime backup/migration/rollback/idempotency and normalized settings CRUD tests pass; targeted lint and format pass",
+  "verifier": "Codex"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/gate-input-pack.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/gate-input-pack.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "baselineRefs": [
+    "openspec/changes/redesign-daily-push-mechanism/design.md",
+    "docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md"
+  ],
+  "impactStatement": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/impact-statement-draft.json",
+  "compatPlan": "Existing /config invocations without source continue to manage leetcode.com and legacy settings migrate without data loss",
+  "retirementPlan": "Combined CRUD, live legacy delivery columns, server-only job IDs, and hard-coded com delivery keys are retired; legacy reads are isolated to the one-way migration owner.",
+  "evidenceBundle": [
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json",
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-final-full-verification-green.json",
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-openspec-strict-validation.json",
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json",
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task2-database-green.json"
+  ]
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/impact-statement-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/impact-statement-draft.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "affectedLayers": [
+    "persistence",
+    "Discord command surface",
+    "scheduler",
+    "API client and UI rendering"
+  ],
+  "owners": [
+    "SettingsDatabaseManager; SlashCommandsCog; ScheduleManagerCog; OjApiClient; ui_helpers"
+  ],
+  "invariants": [
+    "At most one push per server and supported source, with at most three pushes per server"
+  ],
+  "compatBoundary": "Existing /config invocations without source continue to manage leetcode.com and legacy settings migrate without data loss",
+  "nonGoals": [
+    "Multiple pushes for the same source",
+    "Persistent cross-process delivery history",
+    "Changes to upstream source availability rules"
+  ]
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/proof-bundle.md
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/proof-bundle.md
@@ -1,0 +1,33 @@
+# Proof Bundle - 2026-07-18-redesign-daily-push-mechanism
+
+## Method Pack Boundary
+
+This proof bundle is an advisory Aegis Method Pack record. It does not determine evidence sufficiency, produce authoritative `GateDecision`, or grant `completion authority`.
+
+## Task Intent
+
+- Requested outcome: Allow each Discord server to configure one independent scheduled push for each of leetcode.com, sheep, and 0x3f
+- Scope: Database schema and migration, config command behavior, APScheduler job ownership, daily API source selection, multi-problem scheduled rendering, localization, tests, and docs
+
+## Impact
+
+- Compatibility boundary: Existing /config invocations without source continue to manage leetcode.com and legacy settings migrate without data loss
+- Non-goals:
+- Multiple pushes for the same source
+- Persistent cross-process delivery history
+- Changes to upstream source availability rules
+
+## Evidence Bundle Refs
+
+- docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-aegis-workspace-check.json
+- docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-final-full-verification-green.json
+- docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-openspec-strict-validation.json
+- docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task1-schema-assets-green.json
+- docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/evidence-bundle-draft-task2-database-green.json
+
+## Drift Check
+
+- Scope status: Implementation remains within the approved three-source schema, scheduler, config, rendering, localization, tests, and documentation scope.
+- Compatibility status: Source-less config still targets leetcode.com; manual domain calls and legacy reset IDs remain supported; legacy rows are backed up and migrated without dual reads.
+- Retirement status: Combined CRUD, live legacy delivery columns, server-only job IDs, and hard-coded com delivery keys are retired; legacy reads are isolated to the one-way migration owner.
+- Advisory decision: continue

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
@@ -2,12 +2,9 @@
   "schemaVersion": "aegis.schema.v0",
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
   "lastCheckpointRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json",
-  "resumeInstruction": "Read the approved OpenSpec change and latest checkpoint; do not edit runtime code before written-spec approval",
+  "resumeInstruction": "Read Task 2 in the plan and current database.py; preserve Task 1 schema contracts",
   "knownPartialWork": [
-    "Explore current schema, scheduler, API, command, and test owners",
-    "Confirm one push per source and independent per-push fields",
-    "Approve normalized schema and explicit legacy migration",
-    "Write and strictly validate OpenSpec proposal, design, and delta specs"
+    "Task 1 canonical sources and normalized schema assets"
   ],
   "mustReadBeforeContinuing": [
     "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md",
@@ -15,6 +12,6 @@
     "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json"
   ],
   "unsafeToAssume": [
-    "Do not assume written-spec approval from the earlier oral design approval"
+    "Do not infer runtime migration correctness from cleanup utility tests"
   ]
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-18-redesign-daily-push-mechanism",
+  "lastCheckpointRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json",
+  "resumeInstruction": "Read the approved OpenSpec change and latest checkpoint; do not edit runtime code before written-spec approval",
+  "knownPartialWork": [
+    "Explore current schema, scheduler, API, command, and test owners",
+    "Confirm one push per source and independent per-push fields",
+    "Approve normalized schema and explicit legacy migration",
+    "Write and strictly validate OpenSpec proposal, design, and delta specs"
+  ],
+  "mustReadBeforeContinuing": [
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md",
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/20-checkpoint.md",
+    "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json"
+  ],
+  "unsafeToAssume": [
+    "Do not assume written-spec approval from the earlier oral design approval"
+  ]
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
@@ -2,9 +2,10 @@
   "schemaVersion": "aegis.schema.v0",
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
   "lastCheckpointRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json",
-  "resumeInstruction": "Read Task 2 in the plan and current database.py; preserve Task 1 schema contracts",
+  "resumeInstruction": "Read Task 3 and existing daily payload helpers; preserve manual domain behavior",
   "knownPartialWork": [
-    "Task 1 canonical sources and normalized schema assets"
+    "Task 1 canonical sources and schema assets",
+    "Task 2 backed-up migration and normalized CRUD"
   ],
   "mustReadBeforeContinuing": [
     "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md",
@@ -12,6 +13,6 @@
     "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json"
   ],
   "unsafeToAssume": [
-    "Do not infer runtime migration correctness from cleanup utility tests"
+    "Do not treat one-problem get_daily_payload as sufficient for additional sources"
   ]
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/resume-state-hint.json
@@ -2,10 +2,10 @@
   "schemaVersion": "aegis.schema.v0",
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
   "lastCheckpointRef": "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json",
-  "resumeInstruction": "Read Task 3 and existing daily payload helpers; preserve manual domain behavior",
+  "resumeInstruction": "Verify git status, commit final evidence, then use finishing-a-development-branch.",
   "knownPartialWork": [
-    "Task 1 canonical sources and schema assets",
-    "Task 2 backed-up migration and normalized CRUD"
+    "Tasks 1-7 implementation and targeted verification",
+    "Fresh full pytest, Ruff, strict OpenSpec, retirement scan, ADR backfill, and baseline sync closure"
   ],
   "mustReadBeforeContinuing": [
     "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/10-intent.md",
@@ -13,6 +13,6 @@
     "docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json"
   ],
   "unsafeToAssume": [
-    "Do not treat one-problem get_daily_payload as sufficient for additional sources"
+    "Do not claim merge or deployment; only local branch verification is complete."
   ]
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/task-intent-draft.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "requestedOutcome": "Allow each Discord server to configure one independent scheduled push for each of leetcode.com, sheep, and 0x3f",
+  "goal": "Allow each Discord server to configure one independent scheduled push for each of leetcode.com, sheep, and 0x3f",
+  "successEvidence": [
+    "Schema migration preserves legacy LeetCode pushes; each source schedules and delivers independently; targeted and full tests pass"
+  ],
+  "stopCondition": "Done when approved OpenSpec requirements are implemented and verified; otherwise stop as blocked, needs-verification, or scope-exceeded",
+  "nonGoals": [
+    "Multiple pushes for the same source",
+    "Persistent cross-process delivery history",
+    "Changes to upstream source availability rules"
+  ],
+  "scope": "Database schema and migration, config command behavior, APScheduler job ownership, daily API source selection, multi-problem scheduled rendering, localization, tests, and docs",
+  "changeKinds": [
+    "architecture-contract-migration"
+  ],
+  "riskHints": [
+    "Persistent SQLite migration and compatibility of existing /config behavior"
+  ]
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
@@ -1,19 +1,16 @@
 {
   "schemaVersion": "aegis.schema.v0",
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
-  "currentTodo": "Obtain user review of the written specification",
+  "currentTodo": "Implement Task 2 runtime migration and normalized CRUD",
   "completedTodos": [
-    "Explore current schema, scheduler, API, command, and test owners",
-    "Confirm one push per source and independent per-push fields",
-    "Approve normalized schema and explicit legacy migration",
-    "Write and strictly validate OpenSpec proposal, design, and delta specs"
+    "Task 1 canonical sources and normalized schema assets"
   ],
-  "activeSlice": "Written specification review gate",
+  "activeSlice": "Task 2 database migration and CRUD",
   "evidenceRefs": [
-    "openspec validate redesign-daily-push-mechanism --strict: valid",
-    "aegis-workspace.py check --root .: passed"
+    "tests/test_database_schema_assets.py: pass",
+    "targeted Ruff check and format: pass"
   ],
-  "blockedOn": "User review of written specification",
-  "nextStep": "After approval, use writing-plans to create the implementation plan",
+  "blockedOn": null,
+  "nextStep": "Write RED tests in tests/test_settings_database.py",
   "updatedAt": "2026-07-18"
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "aegis.schema.v0",
+  "taskId": "2026-07-18-redesign-daily-push-mechanism",
+  "currentTodo": "Obtain user review of the written specification",
+  "completedTodos": [
+    "Explore current schema, scheduler, API, command, and test owners",
+    "Confirm one push per source and independent per-push fields",
+    "Approve normalized schema and explicit legacy migration",
+    "Write and strictly validate OpenSpec proposal, design, and delta specs"
+  ],
+  "activeSlice": "Written specification review gate",
+  "evidenceRefs": [
+    "openspec validate redesign-daily-push-mechanism --strict: valid",
+    "aegis-workspace.py check --root .: passed"
+  ],
+  "blockedOn": "User review of written specification",
+  "nextStep": "After approval, use writing-plans to create the implementation plan",
+  "updatedAt": "2026-07-18"
+}

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
@@ -1,16 +1,17 @@
 {
   "schemaVersion": "aegis.schema.v0",
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
-  "currentTodo": "Implement Task 2 runtime migration and normalized CRUD",
+  "currentTodo": "Implement Task 3 source-aware API and scheduled rendering",
   "completedTodos": [
-    "Task 1 canonical sources and normalized schema assets"
+    "Task 1 canonical sources and schema assets",
+    "Task 2 backed-up migration and normalized CRUD"
   ],
-  "activeSlice": "Task 2 database migration and CRUD",
+  "activeSlice": "Task 3 daily API and rendering",
   "evidenceRefs": [
-    "tests/test_database_schema_assets.py: pass",
-    "targeted Ruff check and format: pass"
+    "settings/schema/path targeted pytest: pass",
+    "targeted Ruff: pass"
   ],
   "blockedOn": null,
-  "nextStep": "Write RED tests in tests/test_settings_database.py",
+  "nextStep": "Write RED daily source request and multi-problem delivery tests",
   "updatedAt": "2026-07-18"
 }

--- a/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
+++ b/docs/aegis/work/2026-07-18-redesign-daily-push-mechanism/todo-checkpoint-draft.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": "aegis.schema.v0",
   "taskId": "2026-07-18-redesign-daily-push-mechanism",
-  "currentTodo": "Implement Task 3 source-aware API and scheduled rendering",
+  "currentTodo": "Complete final evidence and branch handoff",
   "completedTodos": [
-    "Task 1 canonical sources and schema assets",
-    "Task 2 backed-up migration and normalized CRUD"
+    "Tasks 1-7 implementation and targeted verification",
+    "Fresh full pytest, Ruff, strict OpenSpec, retirement scan, ADR backfill, and baseline sync closure"
   ],
-  "activeSlice": "Task 3 daily API and rendering",
+  "activeSlice": "Task 8 completion evidence",
   "evidenceRefs": [
-    "settings/schema/path targeted pytest: pass",
-    "targeted Ruff: pass"
+    "evidence-bundle-draft-final-full-verification-green.json",
+    "docs/aegis/adr/ADR-0001-normalize-daily-push-ownership-by-source.md"
   ],
   "blockedOn": null,
-  "nextStep": "Write RED daily source request and multi-problem delivery tests",
+  "nextStep": "Commit final evidence and present branch handoff options",
   "updatedAt": "2026-07-18"
 }

--- a/openspec/changes/redesign-daily-push-mechanism/design.md
+++ b/openspec/changes/redesign-daily-push-mechanism/design.md
@@ -1,0 +1,157 @@
+## Context
+
+`SettingsDatabaseManager` currently treats `server_settings.server_id` as both the guild-settings identity and the only daily schedule identity. `ScheduleManagerCog` mirrors that model with one APScheduler job per server, and `/config` edits the same row. This ownership no longer fits three independently configurable daily sources.
+
+The upstream daily API accepts canonical sources `leetcode.com`, `sheep`, and `0x3f` and returns a `{date, source, problems}` envelope. LeetCode normally has one problem; the additional sources may contain multiple problems. Existing overview helpers and problem interaction IDs already provide the correct multi-problem presentation owner.
+
+The user approved a maximum of three pushes per server, exactly one per supported source. Each push has independent channel, role, time, and timezone settings. Language remains guild-wide. The user also explicitly approved removal of the legacy schema representation after backed-up, validated migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Enforce at most one push for each supported source per server at the database boundary.
+- Preserve existing LeetCode push data and source-less `/config` behavior.
+- Keep each source's channel, role, time, timezone, scheduler job, delivery guard, and failure handling independent.
+- Reuse existing API, scheduler, localization, embed, and problem-button owners.
+- Make migration failure recoverable through a pre-migration backup and SQLite transaction rollback.
+
+**Non-Goals:**
+
+- Allow multiple pushes for the same source in one server.
+- Add arbitrary user-defined daily sources.
+- Add persistent delivery history or cross-process idempotency.
+- Duplicate upstream publishing-calendar or crawler configuration logic in the bot.
+- Redesign manual `/daily` or introduce `/daily_extra` as part of this change.
+- Change guild permission requirements for configuration.
+
+## Decisions
+
+### Normalize guild settings and daily push settings
+
+`server_settings` remains the canonical owner of guild-wide language:
+
+```sql
+CREATE TABLE server_settings (
+    server_id INTEGER PRIMARY KEY,
+    language TEXT NOT NULL DEFAULT 'zh-TW',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+`daily_push_settings` becomes the canonical owner of scheduled delivery configuration:
+
+```sql
+CREATE TABLE daily_push_settings (
+    server_id INTEGER NOT NULL,
+    source TEXT NOT NULL CHECK (source IN ('leetcode.com', 'sheep', '0x3f')),
+    channel_id INTEGER NOT NULL,
+    role_id INTEGER,
+    post_time TEXT NOT NULL DEFAULT '00:00',
+    timezone TEXT NOT NULL DEFAULT 'UTC',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (server_id, source),
+    FOREIGN KEY (server_id) REFERENCES server_settings(server_id) ON DELETE CASCADE
+);
+```
+
+The source check plus composite primary key enforces both the source allowlist and the three-push maximum without application-only counting. Settings connections enable SQLite foreign keys so deleting guild settings removes all owned pushes.
+
+Alternative considered: add `source` to the current single table and use `(server_id, source)` as its key. Rejected because it duplicates `language` and permits conflicting guild-wide values.
+
+Alternative considered: add one set of columns per source. Rejected because it hard-codes repeated nullable columns and makes every new source a broad schema edit.
+
+### Keep `/config` backward compatible and source-aware
+
+The existing command remains the public configuration owner. It gains source choices for LeetCode, Sheep, and 0x3f plus a source-specific `remove` option.
+
+- An update containing push fields and no source targets `leetcode.com`.
+- `source:sheep` or `source:0x3f` selects that push.
+- `/config` without parameters lists guild language and all configured pushes.
+- `language` updates `server_settings` and does not require or select a push.
+- `remove:true` requires an explicit source and deletes only that push after confirmation.
+- `reset:true` retains its existing whole-guild meaning and deletes guild settings plus every push after confirmation.
+- `role` and `clear_role` remain mutually exclusive.
+- `remove` and `reset` cannot be combined with other updates.
+- Creating a new source push requires `channel`; partial updates preserve the selected source's other fields.
+
+The UI presents one guild-language field and one compact section per configured source. Confirmation custom IDs carry the action, guild, source when applicable, requesting user, and expiry while remaining below Discord's 100-character limit.
+
+Alternative considered: introduce a new `/push set|list|remove` group. Rejected for this change because `/config` already owns this workflow and a new public command would add migration and documentation cost without enabling required behavior.
+
+### Use canonical source values internally
+
+The database, API client, cache keys, scheduler job IDs, logs, and delivery guard use canonical source values: `leetcode.com`, `sheep`, and `0x3f`. Discord choices may display `LeetCode`, `Sheep`, and `0x3f`, but they resolve to those canonical values before persistence.
+
+The API client adds a source-oriented daily request while retaining domain-based calls used by existing manual commands. It never sends an additional source together with the LeetCode-only `domain` query parameter.
+
+### Schedule one job per server/source pair
+
+APScheduler job identity becomes a deterministic encoding of `(server_id, source)`. Rescheduling one source removes and recreates only that job. Whole-guild reset removes all jobs whose IDs belong to the server.
+
+Startup loads all push rows joined with guild language and recreates every valid job. Invalid time or timezone data skips only the affected source row.
+
+The in-process scheduled-delivery key becomes `(server_id, channel_id, source, daily_date)`. This preserves duplicate prevention for one source without suppressing another source scheduled for the same server, channel, and date.
+
+### Reuse daily envelope and overview rendering
+
+Scheduled delivery fetches the full `{date, source, problems}` payload. A one-problem payload uses the existing daily problem presentation. A multi-problem payload uses `create_problems_overview_embed()` and `create_problems_overview_view()` so each problem remains accessible through the established problem interaction contract.
+
+Role mention behavior and guild locale resolution remain per push execution. Discord embeds and views are built per delivery; only payload retrieval may be reused.
+
+An upstream 404 for an unavailable publishing date is an expected no-delivery result and is logged without posting. Existing processing/retry behavior for HTTP 202 remains in the API client. Other API, channel, and Discord failures remain isolated to the affected push.
+
+### Migrate legacy settings with backup, validation, and rollback
+
+Migration is detected from the legacy `server_settings` columns (`channel_id`, `role_id`, `post_time`, and `timezone`). Before destructive DDL, the bot creates a timestamped SQLite backup beside the runtime database.
+
+Inside one SQLite transaction the migration:
+
+1. Renames the legacy table to a temporary legacy name.
+2. Creates normalized `server_settings` and `daily_push_settings` tables.
+3. Copies each legacy row's guild fields into `server_settings`.
+4. Copies each legacy row's push fields into `daily_push_settings` with `source = 'leetcode.com'`.
+5. Verifies that the migrated guild and push counts equal the legacy row count and that no legacy server ID is missing.
+6. Drops the temporary legacy table only after all checks pass.
+
+Any failure rolls back the transaction and leaves the original database usable. The backup is not automatically deleted. New databases are created directly with normalized tables. The manual cleanup/rebuild utility recognizes both legacy and normalized inputs so cleanup cannot silently discard a legacy LeetCode push.
+
+Alternative considered: retain old push columns as a fallback. Rejected because it creates two persistence owners and makes read/write precedence ambiguous.
+
+## Ownership And Compatibility
+
+| Surface | Canonical owner | Compatibility requirement |
+| --- | --- | --- |
+| Guild language | `server_settings` | Existing language is preserved |
+| Push settings | `daily_push_settings` | Legacy row becomes `leetcode.com` |
+| Configuration UX | `/config` | Source-less push edits target LeetCode |
+| Job lifecycle | `ScheduleManagerCog` | One invalid source does not affect peers |
+| Daily API selection | `OjApiClient` | Existing domain calls keep working |
+| Multi-problem UI | `ui_helpers` overview helpers | Existing problem interaction IDs are reused |
+
+No compatibility fallback reads legacy columns after migration. The backup is the rollback artifact; normalized tables are the only runtime source of truth.
+
+## Risks / Trade-offs
+
+- Schema rebuilding is higher risk than an additive table: mitigated by explicit approval, pre-migration backup, one transaction, row-count and identity validation, and migration tests.
+- `/config` gains more option combinations: mitigate with a small command-input classifier and focused conflict tests instead of embedding more branches directly in the command body.
+- Source names can drift between UI, database, jobs, and API: mitigate with one constants module or existing constants owner for canonical values and labels.
+- Additional sources can legitimately have no payload on some dates: treat upstream 404 as expected no-delivery rather than duplicating the upstream calendar.
+- Multi-problem embeds may exceed Discord limits: retain the existing overview limits and button-count constraints.
+
+## Verification
+
+- Schema tests prove new-table constraints and initialization assets agree.
+- Migration tests prove backup creation, full legacy-to-LeetCode preservation, rollback on validation failure, and idempotent new-schema startup.
+- Database CRUD tests prove independent source updates, source removal, cascade reset, and rejection of unsupported or duplicate sources.
+- Command tests prove source-less LeetCode compatibility, source-specific create/update/remove, global language behavior, conflict validation, and settings display.
+- Scheduler tests prove startup creates up to three independent jobs, targeted rescheduling/removal, source-scoped duplicate prevention, 404 no-delivery, and locale/role preservation.
+- Delivery tests prove one-problem rendering remains unchanged and multi-problem payloads use existing overview helpers.
+- Run targeted tests, full pytest, Ruff checks, and strict OpenSpec validation before completion.
+
+## Architecture Signal
+
+This change establishes a durable source-of-truth split between guild settings and daily push settings and changes scheduler identity from server-only to server/source. Completion should evaluate whether this decision warrants an ADR or whether the archived OpenSpec design is sufficient project authority.
+

--- a/openspec/changes/redesign-daily-push-mechanism/proposal.md
+++ b/openspec/changes/redesign-daily-push-mechanism/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The bot currently stores one notification channel, role, post time, and timezone directly on `server_settings`, so each Discord server can own only one scheduled LeetCode delivery. The upstream daily endpoint now exposes `sheep` and `0x3f` as additional daily sources, both of which may return multiple problems. Server administrators need to schedule those sources independently without duplicating guild-wide settings or losing existing LeetCode schedules.
+
+## What Changes
+
+- Separate guild-wide settings from source-specific daily push settings.
+- Allow each server to configure at most one push for each supported source: `leetcode.com`, `sheep`, and `0x3f`.
+- Keep channel, role, post time, and timezone independent for each source while keeping language shared by the guild.
+- Extend `/config` with a source selector and source-specific removal while preserving existing source-less invocations as LeetCode operations.
+- Create one APScheduler job per `(server_id, source)` and include the source in scheduled-delivery deduplication.
+- Fetch scheduled daily data with the upstream `source` query parameter and render multi-problem responses with the existing overview UI.
+- Migrate legacy `server_settings` schedules to `leetcode.com` after creating a database backup and validating the transactional copy.
+
+## Capabilities
+
+### New Capabilities
+
+None. The change reuses the existing persistence, scheduling, command, API-client, and Discord UI owners.
+
+### Modified Capabilities
+
+- `database-layer`: Normalize guild settings and source-specific push settings, enforce supported sources and per-source uniqueness, and migrate legacy rows safely.
+- `daily-schedule`: Manage and deliver one independent job per configured server/source pair.
+- `slash-commands`: Configure, list, remove, and reset source-specific pushes through the existing `/config` command.
+- `leetcode-client`: Fetch daily payloads by canonical daily source, including `sheep` and `0x3f`.
+
+## Impact
+
+- Affected code: `src/bot/utils/database.py`, `src/bot/cogs/slash_commands_cog.py`, `src/bot/cogs/interaction_handler_cog.py`, `src/bot/cogs/schedule_manager_cog.py`, `src/bot/api_client.py`, `src/bot/utils/ui_helpers.py`, and locale files.
+- Affected schema assets: `data/init_db_schema.sql`, `data/cleanup_runtime_db.py`, and database schema tests.
+- Affected documentation: OpenSpec capability specs and README server configuration examples.
+- Compatibility: existing `/config channel:...`, `/config role:...`, `/config time:...`, and `/config timezone:...` invocations continue to target `leetcode.com`; every legacy schedule is migrated to that source.
+- Data safety: the migration backs up the runtime database, copies and validates legacy schedules in one SQLite transaction, and removes the legacy table representation only after validation succeeds.
+- Dependencies: no new runtime dependency or external service is introduced.
+

--- a/openspec/changes/redesign-daily-push-mechanism/specs/daily-schedule/spec.md
+++ b/openspec/changes/redesign-daily-push-mechanism/specs/daily-schedule/spec.md
@@ -1,0 +1,109 @@
+## MODIFIED Requirements
+
+### Requirement: Per-server daily challenge scheduling
+The system SHALL maintain one independent APScheduler job for each configured `(server_id, source)` daily push. Supported sources SHALL be `leetcode.com`, `sheep`, and `0x3f`, and scheduled output SHALL use the guild's resolved language.
+
+#### Scenario: Schedule initialization on startup
+- **WHEN** the bot starts and `initialize_schedules()` is called
+- **THEN** the system SHALL load every daily push joined with guild language and create one CronTrigger job per valid row
+
+#### Scenario: Three source schedules
+- **WHEN** one server has configured all three supported sources
+- **THEN** the scheduler SHALL own three independent jobs for that server
+
+#### Scenario: Timezone-aware scheduling
+- **WHEN** a push has a configured timezone
+- **THEN** its CronTrigger SHALL use that parsed timezone independently of other pushes
+
+#### Scenario: Invalid timezone in one push
+- **WHEN** one source push has an unparseable timezone
+- **THEN** the system SHALL log and skip only that source without crashing or suppressing the server's other jobs
+
+### Requirement: Schedule management
+The system SHALL support adding, rescheduling, and removing jobs by server and source at runtime.
+
+#### Scenario: Add new source schedule
+- **WHEN** a server configures a new source push with channel and post time
+- **THEN** a job SHALL be created for only that server/source pair
+
+#### Scenario: Reschedule one source
+- **WHEN** a server changes one source's post time or timezone
+- **THEN** only that source's existing job SHALL be replaced
+
+#### Scenario: Remove one source schedule
+- **WHEN** a server removes one source push
+- **THEN** only the corresponding server/source job SHALL be removed
+
+#### Scenario: Reset server schedules
+- **WHEN** a server resets all settings
+- **THEN** every scheduler job owned by that server SHALL be removed
+
+#### Scenario: Invalid time or timezone
+- **WHEN** one stored push has an invalid post time or timezone
+- **THEN** the error SHALL be logged without crashing the bot or removing valid peer jobs
+
+### Requirement: Daily challenge delivery
+The system SHALL fetch and post the configured daily source to the selected channel at the scheduled time using localized UI text. It SHALL prevent concurrent duplicate delivery for the same server, channel, source, and daily date within one bot process.
+
+#### Scenario: Successful source delivery
+- **WHEN** a scheduled Sheep or 0x3f job fires
+- **THEN** the system SHALL fetch the current payload using that canonical source and post it to that push's channel
+
+#### Scenario: Independent role mention
+- **WHEN** one source push has a configured role
+- **THEN** only that source's scheduled message SHALL mention that role
+
+#### Scenario: Successful localized delivery
+- **WHEN** a scheduled job fires for a server with `language = "en-US"`
+- **THEN** the source's embed text, field names, button labels, and footer text SHALL be rendered in English
+
+#### Scenario: Delivery without language setting
+- **WHEN** a scheduled job fires for a server without an explicit language setting
+- **THEN** the system SHALL resolve locale from configured default and hard fallback rules before posting
+
+#### Scenario: Concurrent duplicate source delivery
+- **WHEN** two scheduled attempts for the same server, channel, source, and daily date overlap
+- **THEN** only one attempt SHALL send a Discord message
+
+#### Scenario: Different sources do not collide
+- **WHEN** two different sources run for the same server, channel, and date
+- **THEN** each source SHALL remain eligible to send its own message
+
+#### Scenario: Unavailable source date
+- **WHEN** the upstream daily endpoint returns HTTP 404 for a source's current publishing date
+- **THEN** the scheduled job SHALL log an expected no-delivery result and SHALL NOT post a Discord message
+
+#### Scenario: Multi-problem source payload
+- **WHEN** a scheduled payload contains more than one problem
+- **THEN** the message SHALL use the existing problems overview embed and problem-detail buttons in source order
+
+#### Scenario: Single-problem source payload
+- **WHEN** a scheduled payload contains exactly one problem
+- **THEN** the message SHALL preserve the existing daily problem presentation
+
+### Requirement: Job configuration defaults
+APScheduler jobs SHALL use specific defaults for reliability and SHALL NOT run overlapping instances of the same server/source job.
+
+#### Scenario: Misfire grace time
+- **WHEN** a job misses its scheduled time
+- **THEN** it SHALL still execute if within the 5-minute misfire grace period
+
+#### Scenario: Max instances
+- **WHEN** one server/source job is triggered while its previous instance is still running
+- **THEN** the scheduler SHALL prevent a concurrent second instance of that job
+
+#### Scenario: Peer source concurrency
+- **WHEN** another source job for the same server is ready to run
+- **THEN** the first source's max-instance limit SHALL NOT suppress the peer job
+
+#### Scenario: Coalesced missed runs
+- **WHEN** multiple missed executions for one server/source job are eligible after recovery
+- **THEN** the scheduler SHALL coalesce them into a single execution
+
+### Requirement: Job persistence across restarts
+APScheduler jobs use MemoryJobStore and SHALL be recreated from normalized daily push settings on each bot restart.
+
+#### Scenario: Bot restart
+- **WHEN** the bot restarts
+- **THEN** every valid persisted server/source push SHALL be recreated as an in-memory scheduler job
+

--- a/openspec/changes/redesign-daily-push-mechanism/specs/database-layer/spec.md
+++ b/openspec/changes/redesign-daily-push-mechanism/specs/database-layer/spec.md
@@ -1,0 +1,82 @@
+## MODIFIED Requirements
+
+### Requirement: Settings database management
+The SettingsDatabaseManager SHALL manage guild-wide settings separately from source-specific daily push settings. Guild-wide settings SHALL include language. Each daily push SHALL include server ID, canonical source, notification channel, optional role, post time, and timezone.
+
+#### Scenario: Store guild language
+- **WHEN** a server configures its language
+- **THEN** the language SHALL be persisted once for that server independently of its push rows
+
+#### Scenario: Store independent source pushes
+- **WHEN** a server configures pushes for `leetcode.com`, `sheep`, and `0x3f`
+- **THEN** each source's channel, role, post time, and timezone SHALL be persisted independently
+
+#### Scenario: Update one source
+- **WHEN** a server updates the post time for its `sheep` push
+- **THEN** the `leetcode.com` and `0x3f` push rows SHALL remain unchanged
+
+#### Scenario: Retrieve all server configuration
+- **WHEN** settings are requested for a server
+- **THEN** the manager SHALL return the guild-wide settings and every configured source push
+
+#### Scenario: Default language on new server
+- **WHEN** a server is configured for the first time without specifying language
+- **THEN** the guild language SHALL default to `zh-TW`
+
+### Requirement: Persisted runtime tables
+The runtime SHALL persist settings in normalized `server_settings` and `daily_push_settings` tables alongside `llm_translate_results` and `llm_inspire_results`. The `server_settings` table SHALL own guild language. The `daily_push_settings` table SHALL own source-specific delivery fields and SHALL use `(server_id, source)` as its primary key. LLM cache tables SHALL include `locale` in their primary keys.
+
+#### Scenario: Runtime schema initialization
+- **WHEN** the runtime initializes a new database
+- **THEN** it SHALL create normalized guild settings, daily push settings, and locale-aware LLM cache tables
+
+#### Scenario: Supported push sources
+- **WHEN** a daily push row is inserted
+- **THEN** its source SHALL be one of `leetcode.com`, `sheep`, or `0x3f`
+
+#### Scenario: Maximum pushes per server
+- **WHEN** a server configures every supported source
+- **THEN** the schema SHALL allow exactly one row per source and therefore at most three rows for that server
+
+#### Scenario: Duplicate source rejected
+- **WHEN** a second push row is inserted for the same server and source
+- **THEN** the database primary key SHALL reject the duplicate
+
+#### Scenario: Guild reset cascades to pushes
+- **WHEN** guild settings are deleted
+- **THEN** all daily push rows owned by that server SHALL also be deleted
+
+#### Scenario: Existing LLM cache migration
+- **WHEN** the bot starts with existing LLM cache tables that lack `locale`
+- **THEN** the system SHALL recreate those cache tables because cached LLM responses are derived data
+
+## ADDED Requirements
+
+### Requirement: Legacy push schema migration
+The runtime SHALL migrate the legacy single-push `server_settings` schema to normalized settings without losing existing configuration. It SHALL create a database backup before destructive schema changes and SHALL perform copying, validation, and legacy-table removal in one SQLite transaction.
+
+#### Scenario: Legacy row becomes LeetCode push
+- **WHEN** a legacy server row contains channel, role, post time, timezone, and language
+- **THEN** language SHALL be copied to normalized `server_settings`
+- **AND** the delivery fields SHALL be copied to `daily_push_settings` with source `leetcode.com`
+
+#### Scenario: Migration validation succeeds
+- **WHEN** every legacy server ID exists in both the normalized guild row and migrated LeetCode push row and row counts match
+- **THEN** the migration SHALL remove the temporary legacy table and commit
+
+#### Scenario: Migration validation fails
+- **WHEN** copied row counts or server identities do not match the legacy table
+- **THEN** the migration SHALL roll back and leave the legacy database usable
+
+#### Scenario: Migration backup
+- **WHEN** a legacy schema is detected before destructive DDL
+- **THEN** the runtime SHALL create a timestamped SQLite backup beside the database and SHALL NOT automatically delete it
+
+#### Scenario: Migration is idempotent
+- **WHEN** the bot starts with the normalized schema after a successful migration
+- **THEN** it SHALL reuse that schema without creating another legacy migration backup or duplicate push rows
+
+#### Scenario: Manual cleanup preserves legacy pushes
+- **WHEN** the cleanup utility rebuilds a legacy runtime database
+- **THEN** it SHALL preserve every legacy schedule as a normalized `leetcode.com` push
+

--- a/openspec/changes/redesign-daily-push-mechanism/specs/leetcode-client/spec.md
+++ b/openspec/changes/redesign-daily-push-mechanism/specs/leetcode-client/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Daily challenge fetching
+The API client SHALL fetch current or historical daily challenge envelopes by LeetCode domain or canonical daily source. Canonical sources SHALL include `leetcode.com`, `leetcode.cn`, `sheep`, and `0x3f`, while scheduled server pushes SHALL use `leetcode.com`, `sheep`, or `0x3f`.
+
+#### Scenario: Fetch today's LeetCode challenge by domain
+- **WHEN** the existing manual daily flow requests domain `com` or `cn`
+- **THEN** the client SHALL preserve its domain-based request behavior
+
+#### Scenario: Fetch scheduled LeetCode challenge by source
+- **WHEN** scheduled delivery requests `leetcode.com`
+- **THEN** the client SHALL send `source=leetcode.com` to the daily endpoint
+
+#### Scenario: Fetch additional daily source
+- **WHEN** scheduled delivery requests `sheep` or `0x3f`
+- **THEN** the client SHALL send only that canonical `source` plus any requested date and SHALL NOT send a LeetCode domain
+
+#### Scenario: Preserve daily envelope
+- **WHEN** the upstream endpoint returns a successful daily response
+- **THEN** the client SHALL preserve its `date`, canonical `source`, and ordered `problems` array
+
+#### Scenario: Historical daily challenges
+- **WHEN** a date parameter is provided with a domain or source
+- **THEN** the client SHALL fetch that daily challenge for the specified date
+
+#### Scenario: Processing response retry
+- **WHEN** the upstream endpoint returns HTTP 202 for a source being fetched or requiring ingestion
+- **THEN** the client SHALL preserve the existing bounded processing/retry behavior
+
+#### Scenario: Source date unavailable
+- **WHEN** the upstream endpoint returns HTTP 404 for an unavailable additional-source date
+- **THEN** the client SHALL expose a distinguishable not-found result so scheduled delivery can skip posting
+

--- a/openspec/changes/redesign-daily-push-mechanism/specs/slash-commands/spec.md
+++ b/openspec/changes/redesign-daily-push-mechanism/specs/slash-commands/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Unified config command
+The `/config` command SHALL allow server administrators to view and update guild language plus source-specific daily pushes. Push fields SHALL include source, channel, role, post time, and timezone. Source choices SHALL resolve to `leetcode.com`, `sheep`, or `0x3f`.
+
+#### Scenario: View all settings
+- **WHEN** an administrator runs `/config` without parameters
+- **THEN** the bot SHALL display guild language and every configured source push
+
+#### Scenario: Legacy source-less update
+- **WHEN** an administrator updates channel, role, time, or timezone without specifying source
+- **THEN** the command SHALL update the `leetcode.com` push
+
+#### Scenario: Create source push
+- **WHEN** an administrator runs `/config source:sheep channel:#daily time:08:00 timezone:UTC+8`
+- **THEN** the bot SHALL create or replace only the Sheep push and reschedule only Sheep
+
+#### Scenario: New source requires channel
+- **WHEN** an administrator attempts to configure a source that has no existing push without providing channel
+- **THEN** the command SHALL reject the request with a localized error
+
+#### Scenario: Partial source update
+- **WHEN** an administrator changes the time of an existing 0x3f push
+- **THEN** its channel, role, timezone, and the other source pushes SHALL remain unchanged
+
+#### Scenario: Set guild language
+- **WHEN** an administrator runs `/config language:en-US`
+- **THEN** the bot SHALL update the guild-wide language without selecting or mutating a source push
+
+#### Scenario: Language choice list
+- **WHEN** a user types `/config language:`
+- **THEN** Discord SHALL display a choice list with `zh-TW`, `en-US`, and `zh-CN`
+
+#### Scenario: Permission check
+- **WHEN** a user without `manage_guild` permission runs `/config`
+- **THEN** the bot SHALL respond with a localized permission error
+
+## ADDED Requirements
+
+### Requirement: Source-specific push removal
+The `/config` command SHALL support removing one source push without changing guild language or other source pushes.
+
+#### Scenario: Remove one source
+- **WHEN** an administrator confirms `/config source:sheep remove:true`
+- **THEN** the Sheep push and its scheduler job SHALL be removed
+- **AND** all other guild and push settings SHALL remain unchanged
+
+#### Scenario: Remove requires source
+- **WHEN** an administrator uses `remove:true` without an explicit source
+- **THEN** the command SHALL reject the request rather than defaulting destructive behavior to LeetCode
+
+#### Scenario: Remove conflict
+- **WHEN** `remove:true` is combined with any setting update or `reset:true`
+- **THEN** the command SHALL reject the conflicting request
+
+### Requirement: Whole-guild configuration reset
+The `/config reset:true` operation SHALL retain its whole-guild meaning and SHALL remove guild settings plus every source push only after confirmation.
+
+#### Scenario: Confirm whole-guild reset
+- **WHEN** an administrator confirms a reset
+- **THEN** guild language, all source pushes, and every scheduler job for that server SHALL be removed
+
+#### Scenario: Reset conflict
+- **WHEN** `reset:true` is combined with a source, removal, or setting update
+- **THEN** the command SHALL reject the conflicting request
+
+### Requirement: Source configuration display
+Configuration responses SHALL distinguish guild-wide language from each source's independent push fields.
+
+#### Scenario: Display three pushes
+- **WHEN** a server has configured all supported sources
+- **THEN** `/config` SHALL show one language value and separate LeetCode, Sheep, and 0x3f sections with channel, role, time, and timezone
+
+#### Scenario: Confirmation interaction identity
+- **WHEN** a source removal or whole-guild reset confirmation is created
+- **THEN** its custom ID SHALL identify the action, guild, source when applicable, requesting user, and expiry within Discord's 100-character limit
+

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -9,7 +9,7 @@
 
 - [x] 2.1 Add backed-up transactional legacy migration with row identity/count validation.
 - [x] 2.2 Add normalized guild-language and daily-push CRUD methods.
-- [ ] 2.3 Remove internal reliance on combined legacy settings CRUD.
+- [x] 2.3 Remove internal reliance on combined legacy settings CRUD.
 - [x] 2.4 Add migration, rollback, idempotency, constraint, and CRUD tests.
 
 ## 3. Daily API And Rendering
@@ -28,9 +28,9 @@
 
 ## 5. Configuration And Confirmations
 
-- [ ] 5.1 Extend `/config` with fixed source choices and source-specific removal.
-- [ ] 5.2 Preserve source-less LeetCode edits and global language updates.
-- [ ] 5.3 Display guild language plus all independent push settings.
+- [x] 5.1 Extend `/config` with fixed source choices and source-specific removal.
+- [x] 5.2 Preserve source-less LeetCode edits and global language updates.
+- [x] 5.3 Display guild language plus all independent push settings.
 - [ ] 5.4 Add secure source-removal confirmation while preserving reset.
 - [ ] 5.5 Add command and interaction regression tests, including custom-ID limits.
 

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -31,8 +31,8 @@
 - [x] 5.1 Extend `/config` with fixed source choices and source-specific removal.
 - [x] 5.2 Preserve source-less LeetCode edits and global language updates.
 - [x] 5.3 Display guild language plus all independent push settings.
-- [ ] 5.4 Add secure source-removal confirmation while preserving reset.
-- [ ] 5.5 Add command and interaction regression tests, including custom-ID limits.
+- [x] 5.4 Add secure source-removal confirmation while preserving reset.
+- [x] 5.5 Add command and interaction regression tests, including custom-ID limits.
 
 ## 6. Localization And Documentation
 

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -21,10 +21,10 @@
 
 ## 4. Scheduler
 
-- [ ] 4.1 Create deterministic jobs per `(server_id, source)`.
-- [ ] 4.2 Add targeted source reschedule/removal and whole-server reschedule.
-- [ ] 4.3 Include source in delivery deduplication and logs.
-- [ ] 4.4 Add startup, isolation, error, retry, and deduplication tests.
+- [x] 4.1 Create deterministic jobs per `(server_id, source)`.
+- [x] 4.2 Add targeted source reschedule/removal and whole-server reschedule.
+- [x] 4.3 Include source in delivery deduplication and logs.
+- [x] 4.4 Add startup, isolation, error, retry, and deduplication tests.
 
 ## 5. Configuration And Confirmations
 

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -1,0 +1,49 @@
+## 1. Canonical Sources And Schema
+
+- [ ] 1.1 Add one canonical daily-source constants/validation owner.
+- [ ] 1.2 Normalize runtime init SQL into guild settings and source-specific push settings.
+- [ ] 1.3 Update cleanup/rebuild handling for both legacy and normalized inputs.
+- [ ] 1.4 Add schema asset and constraint coverage.
+
+## 2. Database Migration And CRUD
+
+- [ ] 2.1 Add backed-up transactional legacy migration with row identity/count validation.
+- [ ] 2.2 Add normalized guild-language and daily-push CRUD methods.
+- [ ] 2.3 Remove internal reliance on combined legacy settings CRUD.
+- [ ] 2.4 Add migration, rollback, idempotency, constraint, and CRUD tests.
+
+## 3. Daily API And Rendering
+
+- [ ] 3.1 Add canonical `source` daily API requests without breaking domain calls.
+- [ ] 3.2 Scope daily payload reuse by canonical source/domain identity.
+- [ ] 3.3 Render multi-problem scheduled payloads with existing overview helpers.
+- [ ] 3.4 Preserve single-problem, locale, role mention, and 202/404 behavior.
+
+## 4. Scheduler
+
+- [ ] 4.1 Create deterministic jobs per `(server_id, source)`.
+- [ ] 4.2 Add targeted source reschedule/removal and whole-server reschedule.
+- [ ] 4.3 Include source in delivery deduplication and logs.
+- [ ] 4.4 Add startup, isolation, error, retry, and deduplication tests.
+
+## 5. Configuration And Confirmations
+
+- [ ] 5.1 Extend `/config` with fixed source choices and source-specific removal.
+- [ ] 5.2 Preserve source-less LeetCode edits and global language updates.
+- [ ] 5.3 Display guild language plus all independent push settings.
+- [ ] 5.4 Add secure source-removal confirmation while preserving reset.
+- [ ] 5.5 Add command and interaction regression tests, including custom-ID limits.
+
+## 6. Localization And Documentation
+
+- [ ] 6.1 Add equivalent user-facing keys to all supported locales.
+- [ ] 6.2 Update README configuration examples and migration behavior.
+- [ ] 6.3 Validate locale parity and strict OpenSpec consistency.
+
+## 7. Verification And Retirement
+
+- [ ] 7.1 Run targeted schema, migration, API, rendering, scheduler, command, and interaction tests.
+- [ ] 7.2 Run the full test suite and Ruff checks.
+- [ ] 7.3 Verify no runtime reads or writes legacy push columns or server-only job IDs.
+- [ ] 7.4 Complete architecture, complexity, migration-safety, and evidence review.
+

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -14,10 +14,10 @@
 
 ## 3. Daily API And Rendering
 
-- [ ] 3.1 Add canonical `source` daily API requests without breaking domain calls.
-- [ ] 3.2 Scope daily payload reuse by canonical source/domain identity.
-- [ ] 3.3 Render multi-problem scheduled payloads with existing overview helpers.
-- [ ] 3.4 Preserve single-problem, locale, role mention, and 202/404 behavior.
+- [x] 3.1 Add canonical `source` daily API requests without breaking domain calls.
+- [x] 3.2 Scope daily payload reuse by canonical source/domain identity.
+- [x] 3.3 Render multi-problem scheduled payloads with existing overview helpers.
+- [x] 3.4 Preserve single-problem, locale, role mention, and 202/404 behavior.
 
 ## 4. Scheduler
 

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -42,7 +42,7 @@
 
 ## 7. Verification And Retirement
 
-- [ ] 7.1 Run targeted schema, migration, API, rendering, scheduler, command, and interaction tests.
-- [ ] 7.2 Run the full test suite and Ruff checks.
-- [ ] 7.3 Verify no runtime reads or writes legacy push columns or server-only job IDs.
-- [ ] 7.4 Complete architecture, complexity, migration-safety, and evidence review.
+- [x] 7.1 Run targeted schema, migration, API, rendering, scheduler, command, and interaction tests.
+- [x] 7.2 Run the full test suite and Ruff checks.
+- [x] 7.3 Verify no runtime reads or writes legacy push columns or server-only job IDs.
+- [x] 7.4 Complete architecture, complexity, migration-safety, and evidence review.

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -7,10 +7,10 @@
 
 ## 2. Database Migration And CRUD
 
-- [ ] 2.1 Add backed-up transactional legacy migration with row identity/count validation.
-- [ ] 2.2 Add normalized guild-language and daily-push CRUD methods.
+- [x] 2.1 Add backed-up transactional legacy migration with row identity/count validation.
+- [x] 2.2 Add normalized guild-language and daily-push CRUD methods.
 - [ ] 2.3 Remove internal reliance on combined legacy settings CRUD.
-- [ ] 2.4 Add migration, rollback, idempotency, constraint, and CRUD tests.
+- [x] 2.4 Add migration, rollback, idempotency, constraint, and CRUD tests.
 
 ## 3. Daily API And Rendering
 

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -36,9 +36,9 @@
 
 ## 6. Localization And Documentation
 
-- [ ] 6.1 Add equivalent user-facing keys to all supported locales.
-- [ ] 6.2 Update README configuration examples and migration behavior.
-- [ ] 6.3 Validate locale parity and strict OpenSpec consistency.
+- [x] 6.1 Add equivalent user-facing keys to all supported locales.
+- [x] 6.2 Update README configuration examples and migration behavior.
+- [x] 6.3 Validate locale parity and strict OpenSpec consistency.
 
 ## 7. Verification And Retirement
 

--- a/openspec/changes/redesign-daily-push-mechanism/tasks.md
+++ b/openspec/changes/redesign-daily-push-mechanism/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Canonical Sources And Schema
 
-- [ ] 1.1 Add one canonical daily-source constants/validation owner.
-- [ ] 1.2 Normalize runtime init SQL into guild settings and source-specific push settings.
-- [ ] 1.3 Update cleanup/rebuild handling for both legacy and normalized inputs.
-- [ ] 1.4 Add schema asset and constraint coverage.
+- [x] 1.1 Add one canonical daily-source constants/validation owner.
+- [x] 1.2 Normalize runtime init SQL into guild settings and source-specific push settings.
+- [x] 1.3 Update cleanup/rebuild handling for both legacy and normalized inputs.
+- [x] 1.4 Add schema asset and constraint coverage.
 
 ## 2. Database Migration And CRUD
 
@@ -46,4 +46,3 @@
 - [ ] 7.2 Run the full test suite and Ruff checks.
 - [ ] 7.3 Verify no runtime reads or writes legacy push columns or server-only job IDs.
 - [ ] 7.4 Complete architecture, complexity, migration-safety, and evidence review.
-

--- a/src/bot/api_client.py
+++ b/src/bot/api_client.py
@@ -16,6 +16,16 @@ class ApiError(Exception):
         super().__init__(f"HTTP {status}: {detail}")
 
 
+class ApiDailyNotFoundError(ApiError):
+    def __init__(self, source: str, date: str | None = None):
+        detail = f"No daily challenge found for source {source}"
+        if date:
+            detail += f" on {date}"
+        super().__init__(404, detail)
+        self.source = source
+        self.date = date
+
+
 class ApiProcessingError(Exception):
     def __init__(self, detail: str = "Resource is being processed"):
         self.detail = detail
@@ -167,11 +177,20 @@ class OjApiClient:
     async def get_problem(self, source: str, id: str) -> dict | None:
         return await self._request("GET", f"problems/{quote(source)}/{quote(id)}")
 
-    async def get_daily(self, domain: str = "com", date: str | None = None) -> dict | None:
-        params = {"domain": domain}
+    async def get_daily(
+        self,
+        domain: str = "com",
+        date: str | None = None,
+        *,
+        source: str | None = None,
+    ) -> dict | None:
+        params = {"source": source} if source else {"domain": domain}
         if date:
             params["date"] = date
-        return await self._request("GET", "daily", params=params)
+        result = await self._request("GET", "daily", params=params)
+        if source and result is None:
+            raise ApiDailyNotFoundError(source, date)
+        return result
 
     async def resolve(self, query: str) -> dict | None:
         return await self._request("GET", f"resolve/{quote(query, safe='')}")

--- a/src/bot/app.py
+++ b/src/bot/app.py
@@ -56,10 +56,10 @@ async def load_extensions(bot: commands.Bot) -> None:
 
 
 def _create_reschedule_helper(bot: commands.Bot):
-    async def reschedule_daily_challenge(server_id: int, context: str = ""):
+    async def reschedule_daily_challenge(server_id: int, context: str = "", *, source: str | None = None):
         schedule_cog = bot.get_cog("ScheduleManagerCog")
         if schedule_cog:
-            await schedule_cog.reschedule_daily_challenge(server_id)
+            await schedule_cog.reschedule_daily_challenge(server_id, source)
         else:
             bot.logger.warning(
                 f"ScheduleManagerCog not found during {context} for server {server_id}. "

--- a/src/bot/cogs/interaction_handler_cog.py
+++ b/src/bot/cogs/interaction_handler_cog.py
@@ -14,6 +14,7 @@ from bot.api_client import (
     ApiRateLimitError,
 )
 from bot.leetcode import html_to_text
+from bot.utils.daily_sources import validate_daily_push_source
 from bot.utils.logger import get_commands_logger
 from bot.utils.ui_helpers import (
     _get_locale,
@@ -101,6 +102,58 @@ class InteractionHandlerCog(commands.Cog):
             return
         await self.bot.reschedule_daily_challenge(guild_id, "config_reset")
         await interaction.response.edit_message(content=i18n.t("errors.reset.success", locale), embed=None, view=None)
+
+    async def _handle_config_remove(self, interaction: discord.Interaction):
+        locale = _get_locale(self.bot, interaction)
+        i18n = self.bot.i18n
+
+        custom_id = interaction.data.get("custom_id", "")
+        parts = custom_id.split("|")
+        try:
+            if len(parts) != 5:
+                raise ValueError
+            action, raw_guild_id, raw_user_id, raw_exp_unix, source = parts
+            guild_id = int(raw_guild_id)
+            user_id = int(raw_user_id)
+            exp_unix = int(raw_exp_unix)
+            validate_daily_push_source(source)
+        except (ValueError, TypeError):
+            await interaction.response.send_message(i18n.t("errors.remove.invalid_action", locale), ephemeral=True)
+            return
+
+        if action not in ("config_remove_cancel", "config_remove_confirm"):
+            await interaction.response.send_message(i18n.t("errors.remove.invalid_action", locale), ephemeral=True)
+            return
+        if not interaction.guild or guild_id != interaction.guild.id:
+            await interaction.response.send_message(i18n.t("errors.remove.invalid_action", locale), ephemeral=True)
+            return
+        if user_id != interaction.user.id:
+            await interaction.response.send_message(i18n.t("errors.remove.wrong_user", locale), ephemeral=True)
+            return
+        if int(time.time()) > exp_unix:
+            await interaction.response.send_message(i18n.t("errors.remove.expired", locale), ephemeral=True)
+            return
+
+        if action == "config_remove_cancel":
+            await interaction.response.edit_message(
+                content=i18n.t("errors.remove.cancelled", locale),
+                embed=None,
+                view=None,
+            )
+            return
+
+        if not interaction.user.guild_permissions.manage_guild:
+            await interaction.response.send_message(i18n.t("errors.remove.permission_denied", locale), ephemeral=True)
+            return
+        if not self.bot.db.delete_daily_push(guild_id, source):
+            await interaction.response.send_message(i18n.t("errors.remove.error", locale), ephemeral=True)
+            return
+        await self.bot.reschedule_daily_challenge(guild_id, "config_remove", source=source)
+        await interaction.response.edit_message(
+            content=i18n.t("errors.remove.success", locale),
+            embed=None,
+            view=None,
+        )
 
     # -- Submission navigation (preserved) --
 
@@ -406,6 +459,10 @@ class InteractionHandlerCog(commands.Cog):
             return
 
         custom_id = interaction.data.get("custom_id", "")
+
+        if custom_id.startswith("config_remove_confirm|") or custom_id.startswith("config_remove_cancel|"):
+            await self._handle_config_remove(interaction)
+            return
 
         # Config reset (preserved)
         if custom_id.startswith("config_reset_confirm|") or custom_id.startswith("config_reset_cancel|"):

--- a/src/bot/cogs/schedule_manager_cog.py
+++ b/src/bot/cogs/schedule_manager_cog.py
@@ -8,8 +8,9 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from discord.ext import commands
 
-from bot.api_client import ApiProcessingError, ApiRateLimitError
+from bot.api_client import ApiDailyNotFoundError, ApiProcessingError, ApiRateLimitError
 from bot.utils.config import DEFAULT_POST_TIME, DEFAULT_TIMEZONE, parse_timezone
+from bot.utils.daily_sources import DAILY_PUSH_SOURCE_LABELS, validate_daily_push_source
 from bot.utils.logger import get_scheduler_logger
 from bot.utils.ui_helpers import send_daily_challenge
 
@@ -30,6 +31,10 @@ class ScheduleManagerCog(commands.Cog):
 
         self.scheduler = AsyncIOScheduler(job_defaults=job_defaults, timezone=pytz.UTC)
 
+    @staticmethod
+    def _job_id(server_id: int, source: str) -> str:
+        return f"daily_challenge:{server_id}:{source}"
+
     async def initialize_schedules(self):
         """
         Initialize daily LeetCode challenge schedules for all servers.
@@ -41,53 +46,56 @@ class ScheduleManagerCog(commands.Cog):
         """
         self.logger.info("Initializing APScheduler-based daily challenge schedules...")
 
-        # Start the scheduler
-        self.scheduler.start()
-        self.logger.info("APScheduler started successfully")
+        # Start the scheduler once; whole-runtime reschedules reuse the same instance.
+        if not self.scheduler.running:
+            self.scheduler.start()
+            self.logger.info("APScheduler started successfully")
 
         # Clear any existing jobs to avoid duplicates
         self.scheduler.remove_all_jobs()
 
-        # Get all server settings and create schedules
-        servers = self.bot.db.get_all_servers()
+        # Get all source-specific push settings and create schedules.
+        pushes = self.bot.db.get_all_daily_pushes()
         count = 0
 
-        for server_settings in servers:
-            server_id = server_settings.get("server_id")
+        for push_settings in pushes:
+            server_id = push_settings.get("server_id")
             if not server_id:
-                self.logger.warning(f"Server settings found with no server_id: {server_settings}")
+                self.logger.warning(f"Daily push settings found with no server_id: {push_settings}")
                 continue
 
-            if not server_settings.get("channel_id"):
-                self.logger.info(f"Server {server_id} has no channel_id set, skipping schedule.")
+            if not push_settings.get("channel_id"):
+                self.logger.info(f"Server {server_id} push has no channel_id set, skipping schedule.")
                 continue
 
-            await self.add_server_schedule(server_settings)
-            count += 1
+            if await self.add_server_schedule(push_settings):
+                count += 1
 
-        self.logger.info(f"Total {count} server schedules created with APScheduler.")
+        self.logger.info(f"Total {count} source-specific schedules created with APScheduler.")
 
     async def add_server_schedule(self, server_settings):
-        """Add schedule for a single server using APScheduler"""
+        """Add one server/source schedule using APScheduler."""
         server_id = server_settings.get("server_id")
+        source = server_settings.get("source")
         channel_id = server_settings.get("channel_id")
 
         if not channel_id:
             self.logger.error(f"Attempted to schedule for server {server_id} but no channel_id was provided.")
-            return
+            return False
 
         post_time_str = server_settings.get("post_time", DEFAULT_POST_TIME)
         timezone_str = server_settings.get("timezone", DEFAULT_TIMEZONE)
         role_id = server_settings.get("role_id")
 
         try:
+            validate_daily_push_source(source)
             hour, minute = map(int, post_time_str.split(":"))
             target_timezone = parse_timezone(timezone_str)
 
             # Create cron trigger for daily execution
             trigger = CronTrigger(hour=hour, minute=minute, timezone=target_timezone)
 
-            job_id = f"daily_challenge_{server_id}"
+            job_id = self._job_id(server_id, source)
 
             # Remove existing job if it exists
             if self.scheduler.get_job(job_id):
@@ -98,20 +106,29 @@ class ScheduleManagerCog(commands.Cog):
                 func=self.send_daily_challenge_job,
                 trigger=trigger,
                 id=job_id,
-                args=[server_id, channel_id, role_id, timezone_str],
+                args=[server_id, source, channel_id, role_id, timezone_str],
                 replace_existing=True,
                 misfire_grace_time=300,  # 5 minutes grace time
-                name=f"Daily Challenge for Server {server_id}",
+                name=f"Daily Challenge for Server {server_id} ({source})",
             )
 
-            self.logger.info(f"Scheduled daily challenge for server {server_id} at {post_time_str} {timezone_str}")
+            self.logger.info(
+                "Scheduled daily challenge for server %s, source %s at %s %s",
+                server_id,
+                source,
+                post_time_str,
+                timezone_str,
+            )
+            return True
 
         except ValueError as e:
             self.logger.error(
-                f"Server {server_id}: Invalid schedule config (time={post_time_str}, tz={timezone_str}): {e}"
+                f"Server {server_id}, source {source}: Invalid schedule config "
+                f"(time={post_time_str}, tz={timezone_str}): {e}"
             )
         except Exception as e:
-            self.logger.error(f"Server {server_id}: Error adding schedule: {e}", exc_info=True)
+            self.logger.error(f"Server {server_id}, source {source}: Error adding schedule: {e}", exc_info=True)
+        return False
 
     async def _mark_scheduled_delivery_started(self, delivery_key: tuple[int, int, str, str]) -> bool:
         async with self.scheduled_delivery_lock:
@@ -127,12 +144,17 @@ class ScheduleManagerCog(commands.Cog):
     async def send_daily_challenge_job(
         self,
         server_id: int,
+        source: str,
         channel_id: int,
         role_id: int = None,
         timezone_str: str = DEFAULT_TIMEZONE,
     ):
         """Job function called by APScheduler to send daily challenges"""
-        self.logger.info(f"APScheduler triggered: Sending daily challenge for server {server_id}")
+        self.logger.info(
+            "APScheduler triggered: Sending daily challenge for server %s, source %s",
+            server_id,
+            source,
+        )
 
         # Resolve guild locale: DB setting → config default → zh-TW
         guild_locale = self.bot.i18n.resolve_locale(
@@ -144,14 +166,14 @@ class ScheduleManagerCog(commands.Cog):
 
         scheduled_timezone = parse_timezone(timezone_str)
         daily_date = datetime.now(scheduled_timezone).strftime("%Y-%m-%d")
-        delivery_key = (server_id, channel_id, "com", daily_date)
+        delivery_key = (server_id, channel_id, source, daily_date)
         if not await self._mark_scheduled_delivery_started(delivery_key):
             self.logger.info(
-                "Scheduled daily delivery already in progress for server %s, channel %s, domain %s, "
+                "Scheduled daily delivery already in progress for server %s, channel %s, source %s, "
                 "date %s; skipping duplicate",
                 server_id,
                 channel_id,
-                "com",
+                source,
                 daily_date,
             )
             return
@@ -164,51 +186,77 @@ class ScheduleManagerCog(commands.Cog):
                         channel_id=channel_id,
                         role_id=role_id,
                         guild_locale=guild_locale,
+                        daily_source=source,
                     )
                     if result:
-                        self.logger.info(f"Sent daily challenge for server {server_id}: {result.get('title')}")
+                        self.logger.info(
+                            "Sent daily challenge for server %s, source %s: %s",
+                            server_id,
+                            source,
+                            result.get("title"),
+                        )
                     else:
-                        self.logger.warning(f"Failed to send daily challenge for server {server_id}")
+                        self.logger.warning(f"Failed to send daily challenge for server {server_id}, source {source}")
+                    return
+                except ApiDailyNotFoundError:
+                    self.logger.info("Server %s, source %s: no daily challenge available", server_id, source)
                     return
                 except ApiProcessingError:
                     if attempt < len(delays):
                         delay = delays[attempt] + random.uniform(-0.5, 0.5)
                         self.logger.warning(
-                            f"Server {server_id}: API processing (attempt {attempt + 1}/{len(delays) + 1}), "
+                            f"Server {server_id}, source {source}: API processing "
+                            f"(attempt {attempt + 1}/{len(delays) + 1}), "
                             f"retry in {delay:.1f}s"
                         )
                         await asyncio.sleep(delay)
                         continue
                 except ApiRateLimitError:
-                    self.logger.warning(f"Server {server_id}: rate limited, skipping daily challenge")
+                    self.logger.warning(f"Server {server_id}, source {source}: rate limited, skipping daily challenge")
                     return
                 except Exception as e:
-                    self.logger.error(f"Error in send_daily_challenge_job for server {server_id}: {e}", exc_info=True)
+                    self.logger.error(
+                        f"Error in send_daily_challenge_job for server {server_id}, source {source}: {e}",
+                        exc_info=True,
+                    )
                     return
 
-            self.logger.warning(f"Server {server_id}: API still processing after {len(delays) + 1} attempts, skipping")
+            self.logger.warning(
+                f"Server {server_id}, source {source}: API still processing after {len(delays) + 1} attempts, skipping"
+            )
         finally:
             await self._cleanup_scheduled_delivery(delivery_key)
 
-    async def reschedule_daily_challenge(self, server_id: int = None):
-        """Reschedule the daily challenge for a specific server or all servers"""
+    def _remove_source_job(self, server_id: int, source: str) -> None:
+        job_id = self._job_id(server_id, source)
+        if self.scheduler.get_job(job_id):
+            self.scheduler.remove_job(job_id)
+            self.logger.info("Removed schedule for server %s, source %s", server_id, source)
+
+    async def reschedule_daily_challenge(self, server_id: int = None, source: str = None):
+        """Reschedule one source, every source for a server, or every push."""
         if server_id is not None:
-            self.logger.info(f"Rescheduling daily challenge for server {server_id}...")
-
-            # Remove existing job for this server
-            job_id = f"daily_challenge_{server_id}"
-            if self.scheduler.get_job(job_id):
-                self.scheduler.remove_job(job_id)
-                self.logger.info(f"Removed existing schedule for server {server_id}")
-
-            # Get server settings and add new schedule
-            server_settings = self.bot.db.get_server_settings(server_id)
-            if server_settings and server_settings.get("channel_id"):
-                await self.add_server_schedule(server_settings)
-                self.logger.info(f"Server {server_id} daily challenge has been rescheduled")
+            if source is not None:
+                validate_daily_push_source(source)
+                self.logger.info("Rescheduling daily challenge for server %s, source %s", server_id, source)
+                self._remove_source_job(server_id, source)
+                push_settings = self.bot.db.get_daily_push(server_id, source)
+                if push_settings and push_settings.get("channel_id"):
+                    await self.add_server_schedule(push_settings)
+                    self.logger.info("Server %s, source %s has been rescheduled", server_id, source)
+                else:
+                    self.logger.info("Server %s, source %s has no settings; schedule removed", server_id, source)
             else:
-                self.logger.info(f"Server {server_id} has no valid settings, schedule removed")
+                self.logger.info("Rescheduling every daily source for server %s", server_id)
+                for daily_source in DAILY_PUSH_SOURCE_LABELS:
+                    self._remove_source_job(server_id, daily_source)
+                for push_settings in self.bot.db.get_daily_pushes(server_id):
+                    if push_settings.get("channel_id"):
+                        await self.add_server_schedule(push_settings)
+                self.logger.info("Every daily source for server %s has been rescheduled", server_id)
         else:
+            if source is not None:
+                raise ValueError("source requires server_id for targeted rescheduling")
             self.logger.info("Rescheduling daily challenges for ALL servers...")
             # Remove all existing jobs
             self.scheduler.remove_all_jobs()

--- a/src/bot/cogs/slash_commands_cog.py
+++ b/src/bot/cogs/slash_commands_cog.py
@@ -8,6 +8,11 @@ from discord.ext import commands
 
 from bot.api_client import ApiError, ApiNetworkError, ApiProcessingError, ApiRateLimitError
 from bot.utils.config import DEFAULT_POST_TIME, DEFAULT_TIMEZONE, parse_timezone
+from bot.utils.daily_sources import (
+    DAILY_PUSH_SOURCE_LABELS,
+    DEFAULT_DAILY_PUSH_SOURCE,
+    validate_daily_push_source,
+)
 from bot.utils.logger import get_commands_logger
 from bot.utils.ui_helpers import (
     _get_locale,
@@ -31,8 +36,8 @@ class SlashCommandsCog(commands.Cog):
         self.bot = bot
         self.logger = get_commands_logger()
 
-    async def _reschedule_if_available(self, server_id: int, context: str = ""):
-        await self.bot.reschedule_daily_challenge(server_id, context)
+    async def _reschedule_if_available(self, server_id: int, context: str = "", source: str | None = None):
+        await self.bot.reschedule_daily_challenge(server_id, context, source=source)
 
     # ── /daily ────────────────────────────────────────────────────────
 
@@ -379,6 +384,44 @@ class SlashCommandsCog(commands.Cog):
         app_commands.Choice(name="简体中文", value="zh-CN"),
     ]
 
+    _DAILY_SOURCE_CHOICES = [
+        app_commands.Choice(name=label, value=source) for source, label in DAILY_PUSH_SOURCE_LABELS.items()
+    ]
+
+    def _create_config_embed(
+        self,
+        interaction: discord.Interaction,
+        language: str,
+        pushes: list[dict],
+        locale: str,
+    ) -> discord.Embed:
+        i18n = self.bot.i18n
+        display_pushes = []
+        for push in pushes:
+            display_push = dict(push)
+            channel_id = push["channel_id"]
+            channel = self.bot.get_channel(channel_id)
+            display_push["channel_mention"] = (
+                channel.mention if channel else i18n.t("ui.settings.unknown_channel", locale, id=channel_id)
+            )
+            role_id = push.get("role_id")
+            if role_id:
+                role = interaction.guild.get_role(int(role_id))
+                display_push["role_mention"] = (
+                    role.mention if role else i18n.t("ui.settings.unknown_role", locale, id=role_id)
+                )
+            else:
+                display_push["role_mention"] = i18n.t("ui.settings.not_set", locale)
+            display_pushes.append(display_push)
+
+        return create_settings_embed(
+            interaction.guild.name,
+            pushes=display_pushes,
+            language=language,
+            bot=self.bot,
+            locale=locale,
+        )
+
     @app_commands.command(name="config", description=app_commands.locale_str("config.description"))
     @app_commands.guild_only()
     @app_commands.checks.has_permissions(manage_guild=True)
@@ -390,13 +433,12 @@ class SlashCommandsCog(commands.Cog):
         clear_role=app_commands.locale_str("config.clear_role"),
         language=app_commands.locale_str("config.language"),
         reset=app_commands.locale_str("config.reset"),
+        source=app_commands.locale_str("config.source"),
+        remove=app_commands.locale_str("config.remove"),
     )
     @app_commands.choices(
-        language=[
-            app_commands.Choice(name="繁體中文", value="zh-TW"),
-            app_commands.Choice(name="English", value="en-US"),
-            app_commands.Choice(name="简体中文", value="zh-CN"),
-        ]
+        language=_LANGUAGE_CHOICES,
+        source=_DAILY_SOURCE_CHOICES,
     )
     @app_commands.rename(post_time="time")
     async def config_command(
@@ -409,44 +451,49 @@ class SlashCommandsCog(commands.Cog):
         clear_role: bool = False,
         language: str = None,
         reset: bool = False,
+        source: str = None,
+        remove: bool = False,
     ):
         server_id = interaction.guild.id
 
         locale = _get_locale(self.bot, interaction)
         i18n = self.bot.i18n
 
-        if reset and any([channel, role, post_time is not None, timezone is not None, clear_role, language]):
+        if source is not None:
+            try:
+                validate_daily_push_source(source)
+            except ValueError:
+                await interaction.response.send_message(i18n.t("errors.config.source_invalid", locale), ephemeral=True)
+                return
+
+        push_update_requested = any([channel, role, post_time is not None, timezone is not None, clear_role])
+
+        if remove and any([reset, channel, role, post_time is not None, timezone is not None, clear_role, language]):
+            await interaction.response.send_message(i18n.t("errors.config.remove_conflict", locale), ephemeral=True)
+            return
+        if remove and source is None:
+            await interaction.response.send_message(
+                i18n.t("errors.config.remove_source_required", locale),
+                ephemeral=True,
+            )
+            return
+
+        if reset and any([channel, role, post_time is not None, timezone is not None, clear_role, language, source]):
             await interaction.response.send_message(i18n.t("errors.config.reset_conflict", locale), ephemeral=True)
             return
 
-        has_update = any([channel, role, post_time is not None, timezone is not None, clear_role, language, reset])
+        has_update = push_update_requested or language is not None or reset or remove
         if not has_update:
             settings = self.bot.db.get_server_settings(server_id)
-            if not settings or not settings.get("channel_id"):
+            pushes = self.bot.db.get_daily_pushes(server_id)
+            if not settings and not pushes:
                 await interaction.response.send_message(
                     i18n.t("errors.config.not_configured", locale),
                     ephemeral=True,
                 )
                 return
-            ch = self.bot.get_channel(settings["channel_id"])
-            ch_mention = ch.mention if ch else i18n.t("ui.settings.unknown_channel", locale, id=settings["channel_id"])
-            role_mention = i18n.t("ui.settings.not_set", locale)
-            if settings.get("role_id"):
-                r = interaction.guild.get_role(int(settings["role_id"]))
-                role_mention = r.mention if r else i18n.t("ui.settings.unknown_role", locale, id=settings["role_id"])
-            post_time = settings.get("post_time", DEFAULT_POST_TIME)
-            tz = settings.get("timezone", DEFAULT_TIMEZONE)
-            lang = settings.get("language", "zh-TW")
-            embed = create_settings_embed(
-                interaction.guild.name,
-                ch_mention,
-                role_mention,
-                post_time,
-                tz,
-                language=lang,
-                bot=self.bot,
-                locale=locale,
-            )
+            lang = settings.get("language", "zh-TW") if settings else "zh-TW"
+            embed = self._create_config_embed(interaction, lang, pushes, locale)
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
@@ -455,24 +502,11 @@ class SlashCommandsCog(commands.Cog):
             if not settings:
                 await interaction.response.send_message(i18n.t("errors.config.not_setup", locale), ephemeral=True)
                 return
-            ch = self.bot.get_channel(settings["channel_id"])
-            ch_mention = ch.mention if ch else i18n.t("ui.settings.unknown_channel", locale, id=settings["channel_id"])
-            role_mention = i18n.t("ui.settings.not_set", locale)
-            if settings.get("role_id"):
-                r = interaction.guild.get_role(int(settings["role_id"]))
-                role_mention = r.mention if r else i18n.t("ui.settings.unknown_role", locale, id=settings["role_id"])
-            post_time = settings.get("post_time", DEFAULT_POST_TIME)
-            tz = settings.get("timezone", DEFAULT_TIMEZONE)
-            lang = settings.get("language", "zh-TW")
-            preview_embed = create_settings_embed(
-                interaction.guild.name,
-                ch_mention,
-                role_mention,
-                post_time,
-                tz,
-                language=lang,
-                bot=self.bot,
-                locale=locale,
+            preview_embed = self._create_config_embed(
+                interaction,
+                settings.get("language", "zh-TW"),
+                self.bot.db.get_daily_pushes(server_id),
+                locale,
             )
 
             exp_unix = int(time.time()) + 180
@@ -493,6 +527,54 @@ class SlashCommandsCog(commands.Cog):
             )
             await interaction.response.send_message(
                 content=i18n.t("errors.reset.confirm_message", locale),
+                embed=preview_embed,
+                view=view,
+                ephemeral=True,
+            )
+            return
+
+        if remove:
+            push = self.bot.db.get_daily_push(server_id, source)
+            if not push:
+                await interaction.response.send_message(
+                    i18n.t(
+                        "errors.config.source_not_configured",
+                        locale,
+                        source=DAILY_PUSH_SOURCE_LABELS[source],
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            settings = self.bot.db.get_server_settings(server_id) or {}
+            preview_embed = self._create_config_embed(
+                interaction,
+                settings.get("language", "zh-TW"),
+                [push],
+                locale,
+            )
+            exp_unix = int(time.time()) + 180
+            view = discord.ui.View(timeout=180)
+            view.add_item(
+                discord.ui.Button(
+                    label=i18n.t("ui.buttons.confirm_remove", locale),
+                    style=discord.ButtonStyle.danger,
+                    custom_id=f"config_remove_confirm|{server_id}|{interaction.user.id}|{exp_unix}|{source}",
+                )
+            )
+            view.add_item(
+                discord.ui.Button(
+                    label=i18n.t("ui.buttons.cancel", locale),
+                    style=discord.ButtonStyle.secondary,
+                    custom_id=f"config_remove_cancel|{server_id}|{interaction.user.id}|{exp_unix}|{source}",
+                )
+            )
+            await interaction.response.send_message(
+                content=i18n.t(
+                    "errors.config.remove_confirm_message",
+                    locale,
+                    source=DAILY_PUSH_SOURCE_LABELS[source],
+                ),
                 embed=preview_embed,
                 view=view,
                 ephemeral=True,
@@ -525,31 +607,6 @@ class SlashCommandsCog(commands.Cog):
                 await interaction.response.send_message(tz_err_msg, ephemeral=True)
                 return
 
-        settings = self.bot.db.get_server_settings(server_id)
-        if not settings and not channel:
-            await interaction.response.send_message(
-                i18n.t("errors.config.first_setup_required", locale),
-                ephemeral=True,
-            )
-            return
-
-        base = {
-            "channel_id": settings["channel_id"] if settings else None,
-            "role_id": settings.get("role_id") if settings else None,
-            "post_time": settings.get("post_time", DEFAULT_POST_TIME) if settings else DEFAULT_POST_TIME,
-            "timezone": settings.get("timezone", DEFAULT_TIMEZONE) if settings else DEFAULT_TIMEZONE,
-            "language": settings.get("language", "zh-TW") if settings else "zh-TW",
-        }
-        if channel:
-            base["channel_id"] = channel.id
-        if role:
-            base["role_id"] = role.id
-        if clear_role:
-            base["role_id"] = None
-        if validated_time is not None:
-            base["post_time"] = validated_time
-        if timezone is not None:
-            base["timezone"] = timezone
         if language:
             supported = self.bot.i18n.get_supported_locales()
             if language not in supported:
@@ -558,36 +615,61 @@ class SlashCommandsCog(commands.Cog):
                     ephemeral=True,
                 )
                 return
-            base["language"] = language
 
-        success = self.bot.db.set_server_settings(
-            server_id, base["channel_id"], base["role_id"], base["post_time"], base["timezone"], base["language"]
-        )
+        selected_source = source or DEFAULT_DAILY_PUSH_SOURCE
+        push_success = True
+        if push_update_requested:
+            current_push = self.bot.db.get_daily_push(server_id, selected_source)
+            if not current_push and not channel:
+                await interaction.response.send_message(
+                    i18n.t("errors.config.first_setup_required", locale),
+                    ephemeral=True,
+                )
+                return
 
-        if not success:
+            base = {
+                "channel_id": current_push["channel_id"] if current_push else channel.id,
+                "role_id": current_push.get("role_id") if current_push else None,
+                "post_time": current_push.get("post_time", DEFAULT_POST_TIME) if current_push else DEFAULT_POST_TIME,
+                "timezone": current_push.get("timezone", DEFAULT_TIMEZONE) if current_push else DEFAULT_TIMEZONE,
+            }
+            if channel:
+                base["channel_id"] = channel.id
+            if role:
+                base["role_id"] = role.id
+            if clear_role:
+                base["role_id"] = None
+            if validated_time is not None:
+                base["post_time"] = validated_time
+            if timezone is not None:
+                base["timezone"] = timezone
+
+            push_success = self.bot.db.set_daily_push(
+                server_id,
+                selected_source,
+                base["channel_id"],
+                base["role_id"],
+                base["post_time"],
+                base["timezone"],
+            )
+
+        language_success = self.bot.db.set_server_language(server_id, language) if language else True
+        if not push_success or not language_success:
             await interaction.response.send_message(i18n.t("errors.config.settings_error", locale), ephemeral=True)
             return
 
-        ch_obj = self.bot.get_channel(base["channel_id"])
-        ch_display = ch_obj.mention if ch_obj else i18n.t("ui.settings.unknown_channel", locale, id=base["channel_id"])
-        role_display = i18n.t("ui.settings.not_set", locale)
-        if base["role_id"]:
-            r = interaction.guild.get_role(base["role_id"])
-            role_display = r.mention if r else i18n.t("ui.settings.unknown_role", locale, id=base["role_id"])
-
-        embed = create_settings_embed(
-            interaction.guild.name,
-            ch_display,
-            role_display,
-            base["post_time"],
-            base["timezone"],
-            language=base["language"],
-            bot=self.bot,
-            locale=locale,
+        settings = self.bot.db.get_server_settings(server_id) or {}
+        current_language = language or settings.get("language", "zh-TW")
+        embed = self._create_config_embed(
+            interaction,
+            current_language,
+            self.bot.db.get_daily_pushes(server_id),
+            locale,
         )
         updated_msg = i18n.t("errors.config.settings_updated", locale)
         await interaction.response.send_message(content=updated_msg, embed=embed, ephemeral=True)
-        await self._reschedule_if_available(server_id, "config")
+        if push_update_requested:
+            await self._reschedule_if_available(server_id, "config", selected_source)
 
     @config_command.autocomplete("timezone")
     async def config_timezone_autocomplete(self, interaction: discord.Interaction, current: str):

--- a/src/bot/i18n/locales/en-US.json
+++ b/src/bot/i18n/locales/en-US.json
@@ -31,8 +31,13 @@
     },
     "unexpected": "An unexpected error occurred: {error}",
     "config": {
-      "not_configured": "Daily challenge channel not configured yet. Use /config channel:<channel> to get started.",
+      "not_configured": "No daily push is configured. Use /config channel:<channel> to create the default LeetCode push.",
       "reset_conflict": "`reset` cannot be used with other configuration parameters.",
+      "source_invalid": "Unsupported daily push source.",
+      "remove_conflict": "`remove` cannot be used with other configuration parameters.",
+      "remove_source_required": "You must explicitly specify `source` when removing a push.",
+      "source_not_configured": "No {source} daily push is configured.",
+      "remove_confirm_message": "⚠️ Remove the {source} daily push? Other sources will not be affected.",
       "role_clear_conflict": "`role` and `clear_role` cannot be used together.",
       "time_format_error": "Invalid time format. Please use HH:MM (e.g., 08:00 or 23:59).",
       "timezone_error": "Invalid timezone: {error}",
@@ -54,6 +59,15 @@
       "success": "✅ All settings have been reset and scheduling has been stopped.",
       "confirm_message": "⚠️ Are you sure you want to reset all settings for this server? This will stop the daily challenge schedule."
     },
+    "remove": {
+      "invalid_action": "Invalid action.",
+      "wrong_user": "This action is only available to the original requester.",
+      "expired": "This confirmation has expired. Please use /config remove:True again.",
+      "cancelled": "Daily push removal cancelled.",
+      "permission_denied": "You need the **Manage Server** permission to perform this action.",
+      "error": "An error occurred while removing the daily push. Please try again later.",
+      "success": "✅ The selected daily push has been removed."
+    },
     "navigation": {
       "error": "Navigation error: {error}"
     },
@@ -72,6 +86,7 @@
       "inspire": "Inspiration",
       "similar": "Similar",
       "confirm_reset": "Confirm Reset",
+      "confirm_remove": "Confirm Removal",
       "cancel": "Cancel"
     },
     "embed": {
@@ -109,6 +124,7 @@
       "role": "Role",
       "time": "Post Time",
       "language": "Language",
+      "no_pushes": "No daily pushes configured.",
       "not_set": "Not set",
       "unknown_channel": "Unknown Channel (ID: {id})",
       "unknown_role": "Unknown Role (ID: {id})"
@@ -167,13 +183,15 @@
       "source": "Problem source (e.g., leetcode/atcoder/codeforces), or use source: prefix before problem ID"
     },
     "config": {
-      "description": "Configure all LeetCode Daily Challenge settings",
-      "channel": "Channel to send daily challenges",
+      "description": "Configure source-specific daily problem pushes",
+      "channel": "Channel for the selected source",
       "role": "Role to mention",
       "time": "Send time (HH:MM or H:MM, e.g., 08:00)",
       "timezone": "Timezone (e.g., Asia/Taipei or UTC+8)",
       "clear_role": "Clear role mention setting",
       "reset": "Reset all settings and stop scheduling (requires confirmation)",
+      "source": "Daily problem source (defaults to LeetCode)",
+      "remove": "Remove the selected source push (requires confirmation)",
       "language": "Set the bot's display language",
       "language_current": "Current language: {locale}",
       "language_updated": "✅ Language updated to {locale}"

--- a/src/bot/i18n/locales/zh-CN.json
+++ b/src/bot/i18n/locales/zh-CN.json
@@ -31,8 +31,13 @@
     },
     "unexpected": "发生未预期错误：{error}",
     "config": {
-      "not_configured": "尚未设置 LeetCode 每日挑战频道。使用 /config channel:<频道> 开始设置。",
+      "not_configured": "尚未设置每日推送。使用 /config channel:<频道> 创建默认 LeetCode 推送。",
       "reset_conflict": "`reset` 不可与其他设置参数同时使用。",
+      "source_invalid": "不支持的每日推送来源。",
+      "remove_conflict": "`remove` 不可与其他设置参数同时使用。",
+      "remove_source_required": "移除推送时必须明确指定 `source`。",
+      "source_not_configured": "尚未设置 {source} 每日推送。",
+      "remove_confirm_message": "⚠️ 确定要移除 {source} 每日推送吗？其他来源不受影响。",
       "role_clear_conflict": "`role` 与 `clear_role` 不可同时使用。",
       "time_format_error": "时间格式错误，请使用 HH:MM 格式（例如 08:00 或 23:59）。",
       "timezone_error": "无效的时区：{error}",
@@ -54,6 +59,15 @@
       "success": "✅ 已重置所有设置并停止排程。",
       "confirm_message": "⚠️ 确定要重置此服务器的所有设置吗？这将停止每日挑战排程。"
     },
+    "remove": {
+      "invalid_action": "无效的操作。",
+      "wrong_user": "此操作仅限原发起者使用。",
+      "expired": "此确认已过期，请重新使用 /config remove:True。",
+      "cancelled": "已取消移除推送。",
+      "permission_denied": "您需要「管理服务器」权限才能执行此操作。",
+      "error": "移除推送时发生错误，请稍后再试。",
+      "success": "✅ 已移除指定来源的每日推送。"
+    },
     "navigation": {
       "error": "导航时发生错误：{error}"
     },
@@ -72,6 +86,7 @@
       "inspire": "灵感启发",
       "similar": "相似题目",
       "confirm_reset": "确认重置",
+      "confirm_remove": "确认移除",
       "cancel": "取消"
     },
     "embed": {
@@ -109,6 +124,7 @@
       "role": "标记身份组",
       "time": "发送时间",
       "language": "显示语言",
+      "no_pushes": "尚未设置任何每日推送。",
       "not_set": "未设置",
       "unknown_channel": "未知频道 (ID: {id})",
       "unknown_role": "未知身份组 (ID: {id})"
@@ -167,13 +183,15 @@
       "source": "题库来源 (例如 leetcode/atcoder/codeforces)，也可以在题号前加上 source: 前缀"
     },
     "config": {
-      "description": "设置 LeetCode 每日挑战的所有配置",
-      "channel": "发送每日挑战的频道",
+      "description": "设置各来源的每日题目推送",
+      "channel": "选定来源的发送频道",
       "role": "要标记的身份组",
       "time": "发送时间 (HH:MM 或 H:MM，例如 08:00)",
       "timezone": "时区 (例如 Asia/Taipei 或 UTC+8)",
       "clear_role": "清除身份组标记设置",
       "reset": "重置所有设置并停止排程（需确认）",
+      "source": "每日题目来源（未指定时为 LeetCode）",
+      "remove": "移除选定来源的推送（需确认）",
       "language": "设置机器人的显示语言",
       "language_current": "当前语言：{locale}",
       "language_updated": "✅ 语言已更新为 {locale}"

--- a/src/bot/i18n/locales/zh-TW.json
+++ b/src/bot/i18n/locales/zh-TW.json
@@ -31,8 +31,13 @@
     },
     "unexpected": "發生未預期錯誤：{error}",
     "config": {
-      "not_configured": "尚未設定 LeetCode 每日挑戰頻道。使用 /config channel:<頻道> 開始設定。",
+      "not_configured": "尚未設定每日推送。使用 /config channel:<頻道> 建立預設 LeetCode 推送。",
       "reset_conflict": "`reset` 不可與其他設定參數同時使用。",
+      "source_invalid": "不支援的每日推送來源。",
+      "remove_conflict": "`remove` 不可與其他設定參數同時使用。",
+      "remove_source_required": "移除推送時必須明確指定 `source`。",
+      "source_not_configured": "尚未設定 {source} 每日推送。",
+      "remove_confirm_message": "⚠️ 確定要移除 {source} 每日推送嗎？其他來源不受影響。",
       "role_clear_conflict": "`role` 與 `clear_role` 不可同時使用。",
       "time_format_error": "時間格式錯誤，請使用 HH:MM 格式（例如 08:00 或 23:59）。",
       "timezone_error": "無效的時區：{error}",
@@ -54,6 +59,15 @@
       "success": "✅ 已重置所有設定並停止排程。",
       "confirm_message": "⚠️ 確定要重置此伺服器的所有設定嗎？這將停止每日挑戰排程。"
     },
+    "remove": {
+      "invalid_action": "無效的操作。",
+      "wrong_user": "此操作僅限原發起者使用。",
+      "expired": "此確認已過期，請重新使用 /config remove:True。",
+      "cancelled": "已取消移除推送。",
+      "permission_denied": "您需要「管理伺服器」權限才能執行此操作。",
+      "error": "移除推送時發生錯誤，請稍後再試。",
+      "success": "✅ 已移除指定來源的每日推送。"
+    },
     "navigation": {
       "error": "導航時發生錯誤：{error}"
     },
@@ -72,6 +86,7 @@
       "inspire": "靈感啟發",
       "similar": "相似題目",
       "confirm_reset": "確認重置",
+      "confirm_remove": "確認移除",
       "cancel": "取消"
     },
     "embed": {
@@ -109,6 +124,7 @@
       "role": "標記身分組",
       "time": "發送時間",
       "language": "顯示語言",
+      "no_pushes": "尚未設定任何每日推送。",
       "not_set": "未設定",
       "unknown_channel": "未知頻道 (ID: {id})",
       "unknown_role": "未知身分組 (ID: {id})"
@@ -147,13 +163,15 @@
       "source": "題庫來源 (例如 leetcode/atcoder/codeforces)，也可以在題號前加上 source: 前綴"
     },
     "config": {
-      "description": "設定 LeetCode 每日挑戰的所有配置",
-      "channel": "發送每日挑戰的頻道",
+      "description": "設定各來源的每日題目推送",
+      "channel": "選定來源的發送頻道",
       "role": "要標記的身分組",
       "time": "發送時間 (HH:MM 或 H:MM，例如 08:00)",
       "timezone": "時區 (例如 Asia/Taipei 或 UTC+8)",
       "clear_role": "清除身分組標記設定",
       "reset": "重置所有設定並停止排程（需確認）",
+      "source": "每日題目來源（未指定時為 LeetCode）",
+      "remove": "移除選定來源的推送（需確認）",
       "language": "設定機器人的顯示語言",
       "language_current": "目前語言：{locale}",
       "language_updated": "✅ 語言已更新為 {locale}"

--- a/src/bot/utils/daily_sources.py
+++ b/src/bot/utils/daily_sources.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+DEFAULT_DAILY_PUSH_SOURCE = "leetcode.com"
+DAILY_PUSH_SOURCE_LABELS = {
+    "leetcode.com": "LeetCode",
+    "sheep": "Sheep",
+    "0x3f": "0x3f",
+}
+SUPPORTED_DAILY_PUSH_SOURCES = frozenset(DAILY_PUSH_SOURCE_LABELS)
+
+
+def validate_daily_push_source(source: str) -> str:
+    if source not in SUPPORTED_DAILY_PUSH_SOURCES:
+        supported = ", ".join(DAILY_PUSH_SOURCE_LABELS)
+        raise ValueError(f"Unsupported daily push source: {source}. Expected one of: {supported}")
+    return source

--- a/src/bot/utils/database.py
+++ b/src/bot/utils/database.py
@@ -525,7 +525,14 @@ class LLMInspireDatabaseManager:
 if __name__ == "__main__":
     # Example usage
     db_manager = SettingsDatabaseManager()
-    db_manager.set_server_settings(123456789, 987654321, role_id=111222333, post_time="12:00", timezone="UTC")
-    settings = db_manager.get_server_settings(123456789)
-    logger.debug(settings)
+    db_manager.set_daily_push(
+        123456789,
+        "leetcode.com",
+        987654321,
+        role_id=111222333,
+        post_time="12:00",
+        timezone="UTC",
+    )
+    logger.debug(db_manager.get_server_settings(123456789))
+    logger.debug(db_manager.get_daily_pushes(123456789))
     db_manager.delete_server_settings(123456789)  # Delete settings for server ID 123456789

--- a/src/bot/utils/database.py
+++ b/src/bot/utils/database.py
@@ -3,13 +3,39 @@ import logging
 import os
 import sqlite3
 import time
+from datetime import datetime
 from pathlib import Path
 
+from .daily_sources import DEFAULT_DAILY_PUSH_SOURCE, validate_daily_push_source
 from .paths import get_repo_root, resolve_repo_path
 
 # Module-level logger
 logger = logging.getLogger("database")
 REPO_ROOT = get_repo_root()
+
+SERVER_SETTINGS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS server_settings (
+    server_id INTEGER PRIMARY KEY,
+    language TEXT NOT NULL DEFAULT 'zh-TW',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+DAILY_PUSH_SETTINGS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS daily_push_settings (
+    server_id INTEGER NOT NULL,
+    source TEXT NOT NULL CHECK (source IN ('leetcode.com', 'sheep', '0x3f')),
+    channel_id INTEGER NOT NULL,
+    role_id INTEGER,
+    post_time TEXT NOT NULL DEFAULT '00:00',
+    timezone TEXT NOT NULL DEFAULT 'UTC',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (server_id, source),
+    FOREIGN KEY (server_id) REFERENCES server_settings(server_id) ON DELETE CASCADE
+)
+"""
 
 
 def resolve_db_path(db_path: str | Path) -> str:
@@ -17,50 +43,130 @@ def resolve_db_path(db_path: str | Path) -> str:
 
 
 class SettingsDatabaseManager:
-    """
-    This class manages server settings in the database.
-    """
+    """Manage guild-wide language and source-specific daily push settings."""
 
     def __init__(self, db_path="data/data.db"):
-        """
-        Initialize the database manager
-
-        Args:
-            db_path (str): The path to the database file
-        """
-
         self.db_path = resolve_db_path(db_path)
         Path(os.path.dirname(self.db_path)).mkdir(parents=True, exist_ok=True)
         self._init_db()
         logger.info(f"Database manager initialized with database at {self.db_path}")
 
-    def _init_db(self):
-        """Initialize the database, create necessary tables"""
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
 
-        # Create server settings table
-        cursor.execute("""
-        CREATE TABLE IF NOT EXISTS server_settings (
-            server_id INTEGER PRIMARY KEY,
-            channel_id INTEGER NOT NULL,
-            role_id INTEGER,
-            post_time TEXT DEFAULT '00:00',
-            timezone TEXT DEFAULT 'UTC',
-            language TEXT NOT NULL DEFAULT 'zh-TW',
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    @staticmethod
+    def _table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
+        return (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (table_name,),
+            ).fetchone()
+            is not None
         )
-        """)
 
-        # Migrate: add language column if missing
-        columns = {row[1] for row in cursor.execute("PRAGMA table_info(server_settings)").fetchall()}
-        if "language" not in columns:
-            cursor.execute("ALTER TABLE server_settings ADD COLUMN language TEXT NOT NULL DEFAULT 'zh-TW'")
-            logger.info("Added 'language' column to server_settings")
+    @staticmethod
+    def _table_columns(connection: sqlite3.Connection, table_name: str) -> set[str]:
+        return {row[1] for row in connection.execute(f'PRAGMA table_info("{table_name}")')}
 
-        conn.commit()
-        conn.close()
+    def _has_legacy_server_settings(self, connection: sqlite3.Connection) -> bool:
+        if not self._table_exists(connection, "server_settings"):
+            return False
+        columns = self._table_columns(connection, "server_settings")
+        return bool({"channel_id", "role_id", "post_time", "timezone"} & columns)
+
+    @staticmethod
+    def _create_settings_tables(connection: sqlite3.Connection) -> None:
+        connection.execute(SERVER_SETTINGS_SCHEMA)
+        connection.execute(DAILY_PUSH_SETTINGS_SCHEMA)
+
+    def _create_migration_backup(self, connection: sqlite3.Connection) -> Path:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        backup_path = Path(f"{self.db_path}.{timestamp}.pre-push-redesign.bak")
+        with sqlite3.connect(backup_path) as backup_connection:
+            connection.backup(backup_connection)
+        logger.info("Created pre-migration database backup at %s", backup_path)
+        return backup_path
+
+    def _validate_legacy_migration(self, connection: sqlite3.Connection, expected_count: int) -> None:
+        guild_count = connection.execute("SELECT COUNT(*) FROM server_settings").fetchone()[0]
+        push_count = connection.execute(
+            "SELECT COUNT(*) FROM daily_push_settings WHERE source = ?",
+            (DEFAULT_DAILY_PUSH_SOURCE,),
+        ).fetchone()[0]
+        missing_count = connection.execute(
+            """
+            SELECT COUNT(*)
+            FROM legacy_server_settings AS legacy
+            LEFT JOIN server_settings AS guild ON guild.server_id = legacy.server_id
+            LEFT JOIN daily_push_settings AS push
+                ON push.server_id = legacy.server_id AND push.source = ?
+            WHERE guild.server_id IS NULL OR push.server_id IS NULL
+            """,
+            (DEFAULT_DAILY_PUSH_SOURCE,),
+        ).fetchone()[0]
+        if guild_count != expected_count or push_count != expected_count or missing_count:
+            raise RuntimeError(
+                "Legacy settings migration validation failed: "
+                f"expected={expected_count}, guilds={guild_count}, pushes={push_count}, missing={missing_count}"
+            )
+
+    def _migrate_legacy_server_settings(self, connection: sqlite3.Connection) -> None:
+        legacy_columns = self._table_columns(connection, "server_settings")
+        legacy_count = connection.execute("SELECT COUNT(*) FROM server_settings").fetchone()[0]
+
+        def column_or_default(column: str, default_sql: str) -> str:
+            return f'COALESCE("{column}", {default_sql})' if column in legacy_columns else default_sql
+
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            connection.execute("ALTER TABLE server_settings RENAME TO legacy_server_settings")
+            self._create_settings_tables(connection)
+            connection.execute(
+                f"""
+                INSERT INTO server_settings (server_id, language, created_at, updated_at)
+                SELECT
+                    server_id,
+                    {column_or_default("language", "'zh-TW'")},
+                    {column_or_default("created_at", "CURRENT_TIMESTAMP")},
+                    {column_or_default("updated_at", "CURRENT_TIMESTAMP")}
+                FROM legacy_server_settings
+                """
+            )
+            connection.execute(
+                f"""
+                INSERT INTO daily_push_settings
+                    (server_id, source, channel_id, role_id, post_time, timezone, created_at, updated_at)
+                SELECT
+                    server_id,
+                    ?,
+                    channel_id,
+                    {column_or_default("role_id", "NULL")},
+                    {column_or_default("post_time", "'00:00'")},
+                    {column_or_default("timezone", "'UTC'")},
+                    {column_or_default("created_at", "CURRENT_TIMESTAMP")},
+                    {column_or_default("updated_at", "CURRENT_TIMESTAMP")}
+                FROM legacy_server_settings
+                """,
+                (DEFAULT_DAILY_PUSH_SOURCE,),
+            )
+            self._validate_legacy_migration(connection, legacy_count)
+            connection.execute("DROP TABLE legacy_server_settings")
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+
+        logger.info("Migrated %s legacy server settings rows to normalized daily pushes", legacy_count)
+
+    def _init_db(self) -> None:
+        with self._connect() as connection:
+            if self._has_legacy_server_settings(connection):
+                self._create_migration_backup(connection)
+                self._migrate_legacy_server_settings(connection)
+            else:
+                self._create_settings_tables(connection)
         logger.debug("Database tables initialized")
 
     def get_server_settings(self, server_id):
@@ -72,106 +178,134 @@ class SettingsDatabaseManager:
             Returns:
                 dict: server settings, return None if not found
         """
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
-
-        cursor.execute(
-            "SELECT channel_id, role_id, post_time, timezone, language FROM server_settings WHERE server_id = ?",
-            (server_id,),
-        )
-        result = cursor.fetchone()
-        conn.close()
-
+        with self._connect() as connection:
+            result = connection.execute(
+                "SELECT language FROM server_settings WHERE server_id = ?",
+                (server_id,),
+            ).fetchone()
         if result:
-            logger.debug(f"Server {server_id} settings: {result}")
-            return {
-                "server_id": server_id,
-                "channel_id": result[0],
-                "role_id": result[1],
-                "post_time": result[2],
-                "timezone": result[3],
-                "language": result[4],
-            }
+            return {"server_id": server_id, "language": result[0]}
         return None
 
-    def set_server_settings(
-        self,
-        server_id,
-        channel_id,
-        role_id=None,
-        post_time="00:00",
-        timezone="UTC",
-        language="zh-TW",
-    ):
-        """Set or update server settings
-
-        Args:
-            server_id (int): Discord server ID
-            channel_id (int): The channel ID to send the daily challenge
-            role_id (int, optional): The role ID to mention
-            post_time (str, optional): The time to send the daily challenge, format "HH:MM"
-            timezone (str, optional): The timezone name
-            language (str, optional): The display language, default "zh-TW"
-
-        Returns:
-            bool: return True if updated successfully
-        """
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
-
+    def set_server_language(self, server_id: int, language: str = "zh-TW") -> bool:
         try:
-            cursor.execute(
-                """
-                INSERT INTO server_settings (server_id, channel_id, role_id, post_time, timezone, language)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(server_id) DO UPDATE SET
-                    channel_id = excluded.channel_id,
-                    role_id = excluded.role_id,
-                    post_time = excluded.post_time,
-                    timezone = excluded.timezone,
-                    language = excluded.language,
-                    updated_at = CURRENT_TIMESTAMP
-                """,
-                (server_id, channel_id, role_id, post_time, timezone, language),
-            )
-            conn.commit()
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO server_settings (server_id, language)
+                    VALUES (?, ?)
+                    ON CONFLICT(server_id) DO UPDATE SET
+                        language = excluded.language,
+                        updated_at = CURRENT_TIMESTAMP
+                    """,
+                    (server_id, language),
+                )
             return True
-        except Exception as e:
-            logger.error(f"Error setting server settings: {e}")
+        except sqlite3.Error as exc:
+            logger.error("Error setting server language: %s", exc)
             return False
-        finally:
-            logger.debug(
-                f"Server {server_id} settings updated: ({channel_id}, {role_id}, {post_time}, {timezone}, {language})"
-            )
-            conn.close()
 
-    def get_all_servers(self):
-        """Get all servers with settings
+    @staticmethod
+    def _push_from_row(row: tuple) -> dict:
+        return {
+            "server_id": row[0],
+            "source": row[1],
+            "channel_id": row[2],
+            "role_id": row[3],
+            "post_time": row[4],
+            "timezone": row[5],
+        }
 
-        Returns:
-            list: A list of dictionaries containing all server settings
-        """
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
+    def get_daily_push(self, server_id: int, source: str) -> dict | None:
+        validate_daily_push_source(source)
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT server_id, source, channel_id, role_id, post_time, timezone
+                FROM daily_push_settings
+                WHERE server_id = ? AND source = ?
+                """,
+                (server_id, source),
+            ).fetchone()
+        return self._push_from_row(row) if row else None
 
-        cursor.execute("SELECT server_id, channel_id, role_id, post_time, timezone, language FROM server_settings")
-        results = cursor.fetchall()
-        conn.close()
+    def get_daily_pushes(self, server_id: int) -> list[dict]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT server_id, source, channel_id, role_id, post_time, timezone
+                FROM daily_push_settings
+                WHERE server_id = ?
+                ORDER BY CASE source WHEN 'leetcode.com' THEN 1 WHEN 'sheep' THEN 2 WHEN '0x3f' THEN 3 END
+                """,
+                (server_id,),
+            ).fetchall()
+        return [self._push_from_row(row) for row in rows]
 
-        servers = []
-        for row in results:
-            servers.append(
-                {
-                    "server_id": row[0],
-                    "channel_id": row[1],
-                    "role_id": row[2],
-                    "post_time": row[3],
-                    "timezone": row[4],
-                    "language": row[5],
-                }
-            )
+    def get_all_daily_pushes(self) -> list[dict]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    push.server_id, push.source, push.channel_id, push.role_id,
+                    push.post_time, push.timezone, guild.language
+                FROM daily_push_settings AS push
+                JOIN server_settings AS guild ON guild.server_id = push.server_id
+                ORDER BY push.server_id,
+                    CASE push.source WHEN 'leetcode.com' THEN 1 WHEN 'sheep' THEN 2 WHEN '0x3f' THEN 3 END
+                """
+            ).fetchall()
+        pushes = []
+        for row in rows:
+            push = self._push_from_row(row[:6])
+            push["language"] = row[6]
+            pushes.append(push)
+        return pushes
 
-        return servers
+    def set_daily_push(
+        self,
+        server_id: int,
+        source: str,
+        channel_id: int,
+        role_id: int | None = None,
+        post_time: str = "00:00",
+        timezone: str = "UTC",
+    ) -> bool:
+        validate_daily_push_source(source)
+        try:
+            with self._connect() as connection:
+                connection.execute("INSERT OR IGNORE INTO server_settings (server_id) VALUES (?)", (server_id,))
+                connection.execute(
+                    """
+                    INSERT INTO daily_push_settings
+                        (server_id, source, channel_id, role_id, post_time, timezone)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(server_id, source) DO UPDATE SET
+                        channel_id = excluded.channel_id,
+                        role_id = excluded.role_id,
+                        post_time = excluded.post_time,
+                        timezone = excluded.timezone,
+                        updated_at = CURRENT_TIMESTAMP
+                    """,
+                    (server_id, source, channel_id, role_id, post_time, timezone),
+                )
+            return True
+        except sqlite3.Error as exc:
+            logger.error("Error setting daily push: %s", exc)
+            return False
+
+    def delete_daily_push(self, server_id: int, source: str) -> bool:
+        validate_daily_push_source(source)
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    "DELETE FROM daily_push_settings WHERE server_id = ? AND source = ?",
+                    (server_id, source),
+                )
+            return True
+        except sqlite3.Error as exc:
+            logger.error("Error deleting daily push: %s", exc)
+            return False
 
     def delete_server_settings(self, server_id):
         """Delete server settings
@@ -182,18 +316,13 @@ class SettingsDatabaseManager:
         Returns:
             bool: return True if deleted successfully
         """
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
-
         try:
-            cursor.execute("DELETE FROM server_settings WHERE server_id = ?", (server_id,))
-            conn.commit()
+            with self._connect() as connection:
+                connection.execute("DELETE FROM server_settings WHERE server_id = ?", (server_id,))
             return True
-        except Exception as e:
-            logger.error(f"Error deleting server settings: {e}")
+        except sqlite3.Error as exc:
+            logger.error("Error deleting server settings: %s", exc)
             return False
-        finally:
-            conn.close()
 
 
 class LLMTranslateDatabaseManager:

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -19,6 +19,7 @@ from bot.api_client import ApiDailyNotFoundError, ApiError, ApiNetworkError, Api
 from bot.i18n import I18nService
 from bot.leetcode import generate_history_dates
 
+from .config import DEFAULT_POST_TIME, DEFAULT_TIMEZONE
 from .daily_sources import DAILY_PUSH_SOURCE_LABELS
 from .ui_constants import (
     BUTTON_EMOJIS,
@@ -834,15 +835,12 @@ def create_problems_overview_view(problems: List[Dict[str, Any]], domain: str) -
 
 def create_settings_embed(
     guild_name: str,
-    channel_mention: str,
-    role_mention: str,
-    post_time: str,
-    timezone: str,
+    pushes: list[dict[str, Any]],
     language: str = "zh-TW",
     bot: Any = None,
     locale: str = "zh-TW",
 ) -> discord.Embed:
-    """Create an embed for server settings display"""
+    """Create an embed for guild language and source-specific push settings."""
     i18n = bot.i18n if bot else None
     title = i18n.t("ui.settings.title", locale, guild_name=guild_name) if i18n else f"{guild_name} Settings"
     embed = discord.Embed(title=title, color=DEFAULT_COLOR)
@@ -852,12 +850,29 @@ def create_settings_embed(
     time_label = i18n.t("ui.settings.time", locale) if i18n else "Post Time"
     language_label = i18n.t("ui.settings.language", locale) if i18n else "Language"
 
-    embed.add_field(name=channel_label, value=channel_mention, inline=False)
-    embed.add_field(name=role_label, value=role_mention, inline=False)
-    embed.add_field(name=time_label, value=f"{post_time} ({timezone})", inline=False)
-
     language_display = i18n.t(f"locale.{language}", locale) if i18n else language
     embed.add_field(name=language_label, value=language_display, inline=False)
+
+    if not pushes:
+        no_pushes = i18n.t("ui.settings.no_pushes", locale) if i18n else "No daily pushes configured"
+        embed.add_field(name="Daily Pushes", value=no_pushes, inline=False)
+        return embed
+
+    for push in pushes:
+        source = push.get("source", "")
+        source_label = DAILY_PUSH_SOURCE_LABELS.get(source, source)
+        channel_mention = push.get("channel_mention", str(push.get("channel_id", "")))
+        role_mention = push.get("role_mention", i18n.t("ui.settings.not_set", locale) if i18n else "Not set")
+        post_time = push.get("post_time", DEFAULT_POST_TIME)
+        timezone_name = push.get("timezone", DEFAULT_TIMEZONE)
+        value = "\n".join(
+            [
+                f"**{channel_label}**: {channel_mention}",
+                f"**{role_label}**: {role_mention}",
+                f"**{time_label}**: {post_time} ({timezone_name})",
+            ]
+        )
+        embed.add_field(name=source_label, value=value, inline=False)
 
     return embed
 

--- a/src/bot/utils/ui_helpers.py
+++ b/src/bot/utils/ui_helpers.py
@@ -15,10 +15,11 @@ from typing import Any, Dict, List, Optional
 import discord
 import pytz
 
-from bot.api_client import ApiError, ApiNetworkError, ApiProcessingError, ApiRateLimitError
+from bot.api_client import ApiDailyNotFoundError, ApiError, ApiNetworkError, ApiProcessingError, ApiRateLimitError
 from bot.i18n import I18nService
 from bot.leetcode import generate_history_dates
 
+from .daily_sources import DAILY_PUSH_SOURCE_LABELS
 from .ui_constants import (
     BUTTON_EMOJIS,
     DEFAULT_COLOR,
@@ -983,7 +984,21 @@ async def _fetch_daily_history(bot: Any, domain: str, anchor_date: str) -> List[
                 return None
 
     results = await asyncio.gather(*[fetch_one(d) for d in history_dates])
-    return [r for r in results if r]
+    history_problems = []
+    for result in results:
+        problems = _get_daily_problems(result)
+        if problems:
+            history_problems.append(problems[0])
+    return history_problems
+
+
+def _get_daily_problems(daily_info: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not daily_info:
+        return []
+    problems = daily_info.get("problems")
+    if isinstance(problems, list):
+        return [problem for problem in problems if isinstance(problem, dict)]
+    return [daily_info]
 
 
 async def _fetch_daily_payload(
@@ -991,31 +1006,48 @@ async def _fetch_daily_payload(
     domain: str,
     date_str: str | None,
     fallback_date: str,
+    source: str | None,
 ) -> dict[str, Any] | None:
-    if date_str:
-        challenge_info = await bot.api.get_daily(domain, date_str)
+    if source:
+        if date_str:
+            daily_info = await bot.api.get_daily(date=date_str, source=source)
+        else:
+            daily_info = await bot.api.get_daily(source=source)
+    elif date_str:
+        daily_info = await bot.api.get_daily(domain, date_str)
     else:
-        challenge_info = await bot.api.get_daily(domain)
-    if not challenge_info:
+        daily_info = await bot.api.get_daily(domain)
+    problems = _get_daily_problems(daily_info)
+    if not problems:
         return None
 
-    history_anchor = challenge_info.get("date") or date_str or fallback_date
-    history_problems = await _fetch_daily_history(bot, domain, history_anchor)
+    challenge_info = problems[0]
+    history_anchor = daily_info.get("date") or challenge_info.get("date") or date_str or fallback_date
+    history_problems = [] if source else await _fetch_daily_history(bot, domain, history_anchor)
     return {
         "challenge_info": challenge_info,
+        "problems": problems,
+        "daily_source": daily_info.get("source") or source,
         "history_problems": history_problems,
         "resolved_date": history_anchor,
     }
 
 
-async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None = None) -> dict[str, Any] | None:
+async def get_daily_payload(
+    bot: Any,
+    domain: str = "com",
+    date_str: str | None = None,
+    *,
+    source: str | None = None,
+) -> dict[str, Any] | None:
     fallback_date = datetime.now(pytz.UTC).strftime("%Y-%m-%d")
-    cache_key = (domain, date_str or f"{_CURRENT_DAILY_PAYLOAD_KEY}:{fallback_date}")
+    cache_namespace = source or domain
+    cache_key = (cache_namespace, date_str or f"{_CURRENT_DAILY_PAYLOAD_KEY}:{fallback_date}")
     cache, in_flight, lock = _get_daily_payload_state(bot)
 
     async def fetch_and_cleanup() -> dict[str, Any] | None:
         try:
-            return await _fetch_daily_payload(bot, domain, date_str, fallback_date)
+            return await _fetch_daily_payload(bot, domain, date_str, fallback_date, source)
         finally:
             current_task = asyncio.current_task()
             async with lock:
@@ -1047,7 +1079,7 @@ async def get_daily_payload(bot: Any, domain: str = "com", date_str: str | None 
             cache[cache_key] = (inserted_at, payload)
             actual_date = payload.get("resolved_date")
             if actual_date and (date_str or payload["challenge_info"].get("date")):
-                cache[(domain, actual_date)] = (inserted_at, payload)
+                cache[(cache_namespace, actual_date)] = (inserted_at, payload)
     return payload
 
 
@@ -1060,6 +1092,7 @@ async def send_daily_challenge(
     ephemeral: bool = True,
     guild_locale: str = None,
     date_str: str | None = None,
+    daily_source: str | None = None,
 ):
     """Fetches and sends the daily challenge via API."""
     if interaction:
@@ -1071,28 +1104,54 @@ async def send_daily_challenge(
     i18n = bot.i18n
 
     try:
-        logger.info("Attempting to send daily challenge. Domain: %s, Channel: %s", domain, channel_id)
+        logger.info(
+            "Attempting to send daily challenge. Domain: %s, Source: %s, Channel: %s",
+            domain,
+            daily_source,
+            channel_id,
+        )
 
-        payload = await get_daily_payload(bot, domain, date_str)
+        payload = await get_daily_payload(bot, domain, date_str, source=daily_source)
         if not payload:
-            logger.error("No daily challenge for domain %s", domain)
+            logger.error("No daily challenge for domain %s, source %s", domain, daily_source)
             if interaction:
                 await interaction.followup.send(i18n.t("ui.embed.not_found", locale), ephemeral=ephemeral)
             return None
 
         challenge_info = payload["challenge_info"]
-        logger.info("Got daily challenge: %s. %s for domain %s", challenge_info["id"], challenge_info["title"], domain)
-
-        embed = await create_problem_embed(
-            problem_info=challenge_info,
-            bot=bot,
-            domain=domain,
-            is_daily=True,
-            date_str=date_str or payload.get("resolved_date"),
-            history_problems=payload["history_problems"],
-            locale=locale,
+        problems = payload.get("problems") or [challenge_info]
+        logger.info(
+            "Got daily challenge with %s problem(s) for domain %s, source %s",
+            len(problems),
+            domain,
+            daily_source,
         )
-        view = await create_problem_view(problem_info=challenge_info, bot=bot, domain=domain, locale=locale)
+
+        if len(problems) > 1:
+            source_label = DAILY_PUSH_SOURCE_LABELS.get(
+                daily_source or payload.get("daily_source"),
+                daily_source or payload.get("daily_source") or "Daily",
+            )
+            embed = create_problems_overview_embed(
+                problems,
+                domain,
+                source_label=source_label,
+                footer_icon_url=get_source_logo_url(problems[0].get("source")),
+                bot=bot,
+                locale=locale,
+            )
+            view = create_problems_overview_view(problems, domain)
+        else:
+            embed = await create_problem_embed(
+                problem_info=challenge_info,
+                bot=bot,
+                domain=domain,
+                is_daily=True,
+                date_str=date_str or payload.get("resolved_date"),
+                history_problems=payload["history_problems"],
+                locale=locale,
+            )
+            view = await create_problem_view(problem_info=challenge_info, bot=bot, domain=domain, locale=locale)
 
         if interaction:
             await interaction.followup.send(embed=embed, view=view, ephemeral=ephemeral)
@@ -1119,6 +1178,12 @@ async def send_daily_challenge(
 
         return challenge_info
 
+    except ApiDailyNotFoundError:
+        logger.info("No daily challenge available for source %s", daily_source)
+        if interaction:
+            await interaction.followup.send(i18n.t("ui.embed.not_found", locale), ephemeral=ephemeral)
+            return None
+        raise
     except (ApiProcessingError, ApiRateLimitError) as e:
         logger.warning("API error in send_daily_challenge: %s", e)
         if interaction:

--- a/tests/test_bootstrap_and_paths.py
+++ b/tests/test_bootstrap_and_paths.py
@@ -141,8 +141,17 @@ def test_database_manager_resolves_default_path_from_repo_root(tmp_path, monkeyp
             return None
 
     class DummyConnection:
+        def execute(self, *_args, **_kwargs):
+            return DummyCursorResult()
+
         def cursor(self):
             return DummyCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
 
         def commit(self):
             return None

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -1,0 +1,211 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from bot.cogs import slash_commands_cog as slash_module
+from bot.cogs.slash_commands_cog import SlashCommandsCog
+from bot.utils.ui_helpers import create_settings_embed
+
+
+def _push(source: str, *, channel_id: int = 100, role_id: int | None = None) -> dict:
+    return {
+        "server_id": 123,
+        "source": source,
+        "channel_id": channel_id,
+        "role_id": role_id,
+        "post_time": "08:00",
+        "timezone": "Asia/Taipei",
+    }
+
+
+def _make_bot(*, settings: dict | None = None, pushes: list[dict] | None = None):
+    bot = MagicMock()
+    bot.config = SimpleNamespace(default_locale="zh-TW")
+    bot.i18n = MagicMock()
+    bot.i18n.resolve_locale.return_value = "zh-TW"
+    bot.i18n.get_supported_locales.return_value = ["zh-TW", "en-US", "zh-CN"]
+    bot.i18n.t.side_effect = lambda key, _locale, **kwargs: key + (f":{kwargs}" if kwargs else "")
+    bot.db = MagicMock()
+    bot.db.get_server_settings.return_value = settings
+    bot.db.get_daily_pushes.return_value = pushes or []
+    bot.db.get_daily_push.side_effect = lambda _server_id, source: next(
+        (push for push in (pushes or []) if push["source"] == source),
+        None,
+    )
+    bot.db.set_server_language.return_value = True
+    bot.db.set_daily_push.return_value = True
+    bot.get_channel.side_effect = lambda channel_id: SimpleNamespace(mention=f"<#{channel_id}>")
+    bot.reschedule_daily_challenge = AsyncMock()
+    return bot
+
+
+def _make_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.guild = MagicMock()
+    interaction.guild.id = 123
+    interaction.guild.name = "Test Guild"
+    interaction.guild.get_role.side_effect = lambda role_id: SimpleNamespace(mention=f"<@&{role_id}>")
+    interaction.user = MagicMock()
+    interaction.user.id = 9_999_999_999_999_999_999
+    interaction.user.guild_permissions.manage_guild = True
+    interaction.guild_locale = None
+    interaction.locale = discord.Locale.taiwan_chinese
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+async def _invoke_config(cog, interaction, **overrides):
+    params = {
+        "channel": None,
+        "role": None,
+        "post_time": None,
+        "timezone": None,
+        "clear_role": False,
+        "language": None,
+        "reset": False,
+        "source": None,
+        "remove": False,
+    }
+    params.update(overrides)
+    await cog.config_command.callback(cog, interaction, **params)
+
+
+def test_config_source_choices_are_fixed_to_supported_daily_sources():
+    source_param = next(param for param in SlashCommandsCog.config_command.parameters if param.name == "source")
+
+    assert [choice.value for choice in source_param.choices] == ["leetcode.com", "sheep", "0x3f"]
+
+
+def test_settings_embed_displays_language_and_each_independent_push():
+    pushes = []
+    for index, source in enumerate(("leetcode.com", "sheep", "0x3f"), start=1):
+        push = _push(source, channel_id=index, role_id=index + 10)
+        push["channel_mention"] = f"<#{index}>"
+        push["role_mention"] = f"<@&{index + 10}>"
+        pushes.append(push)
+
+    embed = create_settings_embed("Test Guild", pushes=pushes, language="en-US")
+
+    assert [field.name for field in embed.fields] == ["Language", "LeetCode", "Sheep", "0x3f"]
+    assert "<#2>" in embed.fields[2].value
+    assert "08:00 (Asia/Taipei)" in embed.fields[3].value
+
+
+@pytest.mark.asyncio
+async def test_config_without_updates_displays_language_and_all_pushes(monkeypatch):
+    pushes = [_push("leetcode.com"), _push("sheep", channel_id=200)]
+    bot = _make_bot(settings={"server_id": 123, "language": "en-US"}, pushes=pushes)
+    interaction = _make_interaction()
+    embed = discord.Embed(title="settings")
+    create_embed = MagicMock(return_value=embed)
+    monkeypatch.setattr(slash_module, "create_settings_embed", create_embed)
+
+    await _invoke_config(SlashCommandsCog(bot), interaction)
+
+    kwargs = create_embed.call_args.kwargs
+    assert kwargs["language"] == "en-US"
+    assert [push["source"] for push in kwargs["pushes"]] == ["leetcode.com", "sheep"]
+    interaction.response.send_message.assert_awaited_once_with(embed=embed, ephemeral=True)
+
+
+@pytest.mark.asyncio
+async def test_source_less_push_update_targets_leetcode_and_preserves_other_fields(monkeypatch):
+    current = _push("leetcode.com", channel_id=100, role_id=300)
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"}, pushes=[current])
+    interaction = _make_interaction()
+    monkeypatch.setattr(slash_module, "create_settings_embed", MagicMock(return_value=discord.Embed()))
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, post_time="9:05")
+
+    bot.db.set_daily_push.assert_called_once_with(123, "leetcode.com", 100, 300, "09:05", "Asia/Taipei")
+    bot.reschedule_daily_challenge.assert_awaited_once_with(123, "config", source="leetcode.com")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["leetcode.com", "sheep", "0x3f"])
+async def test_config_creates_each_supported_source(source, monkeypatch):
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"})
+    interaction = _make_interaction()
+    channel = SimpleNamespace(id=555)
+    monkeypatch.setattr(slash_module, "create_settings_embed", MagicMock(return_value=discord.Embed()))
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, source=source, channel=channel)
+
+    bot.db.set_daily_push.assert_called_once_with(123, source, 555, None, "00:00", "UTC")
+    bot.reschedule_daily_challenge.assert_awaited_once_with(123, "config", source=source)
+
+
+@pytest.mark.asyncio
+async def test_language_only_update_does_not_require_or_create_push(monkeypatch):
+    bot = _make_bot()
+    interaction = _make_interaction()
+    monkeypatch.setattr(slash_module, "create_settings_embed", MagicMock(return_value=discord.Embed()))
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, language="en-US")
+
+    bot.db.set_server_language.assert_called_once_with(123, "en-US")
+    bot.db.set_daily_push.assert_not_called()
+    bot.reschedule_daily_challenge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_new_selected_source_requires_channel():
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"})
+    interaction = _make_interaction()
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, source="sheep", timezone="UTC+8")
+
+    bot.db.set_daily_push.assert_not_called()
+    assert interaction.response.send_message.await_args.args[0].startswith("errors.config.first_setup_required")
+
+
+@pytest.mark.asyncio
+async def test_config_rejects_role_and_clear_role_conflict():
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"}, pushes=[_push("leetcode.com")])
+    interaction = _make_interaction()
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, role=SimpleNamespace(id=42), clear_role=True)
+
+    bot.db.set_daily_push.assert_not_called()
+    assert interaction.response.send_message.await_args.args[0].startswith("errors.config.role_clear_conflict")
+
+
+@pytest.mark.asyncio
+async def test_remove_requires_explicit_source():
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"}, pushes=[_push("leetcode.com")])
+    interaction = _make_interaction()
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, remove=True)
+
+    assert interaction.response.send_message.await_args.args[0].startswith("errors.config.remove_source_required")
+
+
+@pytest.mark.asyncio
+async def test_remove_and_reset_conflict():
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"}, pushes=[_push("sheep")])
+    interaction = _make_interaction()
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, source="sheep", remove=True, reset=True)
+
+    assert interaction.response.send_message.await_args.args[0].startswith("errors.config.remove_conflict")
+
+
+@pytest.mark.asyncio
+async def test_remove_builds_source_specific_confirmation_under_custom_id_limit(monkeypatch):
+    bot = _make_bot(settings={"server_id": 123, "language": "zh-TW"}, pushes=[_push("0x3f")])
+    interaction = _make_interaction()
+    monkeypatch.setattr(slash_module.time, "time", lambda: 9_999_999_999)
+    monkeypatch.setattr(slash_module, "create_settings_embed", MagicMock(return_value=discord.Embed()))
+
+    await _invoke_config(SlashCommandsCog(bot), interaction, source="0x3f", remove=True)
+
+    view = interaction.response.send_message.await_args.kwargs["view"]
+    custom_ids = [item.custom_id for item in view.children]
+    assert custom_ids == [
+        "config_remove_confirm|123|9999999999999999999|10000000179|0x3f",
+        "config_remove_cancel|123|9999999999999999999|10000000179|0x3f",
+    ]
+    assert max(map(len, custom_ids)) <= 100

--- a/tests/test_daily_source_delivery.py
+++ b/tests/test_daily_source_delivery.py
@@ -1,0 +1,178 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord.ext import commands
+
+from bot.api_client import ApiDailyNotFoundError, OjApiClient
+from bot.utils import ui_helpers
+from bot.utils.ui_helpers import get_daily_payload, send_daily_challenge
+
+
+def _problem(problem_id: str, title: str) -> dict:
+    return {
+        "id": problem_id,
+        "source": "codeforces",
+        "slug": problem_id,
+        "title": title,
+        "difficulty": "1500",
+        "rating": 1500,
+        "tags": ["dp"],
+        "link": f"https://codeforces.com/problemset/problem/{problem_id}",
+    }
+
+
+def _bot_with_daily(daily: dict):
+    bot = MagicMock(spec=commands.Bot)
+    bot.api = SimpleNamespace(get_daily=AsyncMock(return_value=daily))
+    bot.config = SimpleNamespace(default_locale="zh-TW")
+    bot.i18n = MagicMock()
+    bot.i18n.t = MagicMock(side_effect=lambda key, locale, **kwargs: key.format(**kwargs))
+    bot.llm = MagicMock()
+    bot.llm_pro = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    channel.guild.get_role.return_value = None
+    bot.get_channel.return_value = channel
+    return bot, channel
+
+
+@pytest.mark.asyncio
+async def test_api_client_get_daily_uses_source_without_domain():
+    client = OjApiClient("https://example.test/api/v1")
+    client._request = AsyncMock(return_value={"date": "2026-06-09", "source": "sheep", "problems": []})
+
+    await client.get_daily(date="2026-06-09", source="sheep")
+
+    client._request.assert_awaited_once_with(
+        "GET",
+        "daily",
+        params={"source": "sheep", "date": "2026-06-09"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_client_get_daily_preserves_domain_calls():
+    client = OjApiClient("https://example.test/api/v1")
+    client._request = AsyncMock(return_value={"id": "1"})
+
+    await client.get_daily("cn", "2026-06-09")
+
+    client._request.assert_awaited_once_with(
+        "GET",
+        "daily",
+        params={"domain": "cn", "date": "2026-06-09"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_client_distinguishes_missing_additional_source():
+    client = OjApiClient("https://example.test/api/v1")
+    client._request = AsyncMock(return_value=None)
+
+    with pytest.raises(ApiDailyNotFoundError):
+        await client.get_daily(source="0x3f")
+
+
+@pytest.mark.asyncio
+async def test_daily_payload_cache_is_isolated_by_source(monkeypatch):
+    responses = {
+        "sheep": {"date": "2026-06-09", "source": "sheep", "problems": [_problem("1A", "A")]},
+        "0x3f": {"date": "2026-06-09", "source": "0x3f", "problems": [_problem("2B", "B")]},
+    }
+    bot, _ = _bot_with_daily(responses["sheep"])
+
+    async def get_daily(*_args, source=None, **_kwargs):
+        return responses[source]
+
+    bot.api.get_daily.side_effect = get_daily
+    monkeypatch.setattr(ui_helpers, "generate_history_dates", lambda _anchor: [])
+
+    sheep = await get_daily_payload(bot, date_str="2026-06-09", source="sheep")
+    zero_x3f = await get_daily_payload(bot, date_str="2026-06-09", source="0x3f")
+    sheep_again = await get_daily_payload(bot, date_str="2026-06-09", source="sheep")
+
+    assert sheep["challenge_info"]["id"] == "1A"
+    assert zero_x3f["challenge_info"]["id"] == "2B"
+    assert sheep_again is sheep
+    assert bot.api.get_daily.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_multi_problem_source_uses_existing_overview_helpers(monkeypatch):
+    daily = {
+        "date": "2026-06-09",
+        "source": "sheep",
+        "problems": [_problem("1A", "A"), _problem("2B", "B")],
+    }
+    bot, channel = _bot_with_daily(daily)
+    overview_embed = discord.Embed(title="Sheep Daily")
+    overview_view = MagicMock()
+    create_overview_embed = MagicMock(return_value=overview_embed)
+    create_overview_view = MagicMock(return_value=overview_view)
+    create_problem_embed = AsyncMock()
+    monkeypatch.setattr(ui_helpers, "create_problems_overview_embed", create_overview_embed)
+    monkeypatch.setattr(ui_helpers, "create_problems_overview_view", create_overview_view)
+    monkeypatch.setattr(ui_helpers, "create_problem_embed", create_problem_embed)
+
+    result = await send_daily_challenge(bot=bot, channel_id=123, daily_source="sheep", guild_locale="zh-TW")
+
+    bot.api.get_daily.assert_awaited_once_with(source="sheep")
+    create_overview_embed.assert_called_once()
+    create_overview_view.assert_called_once_with(daily["problems"], "com")
+    create_problem_embed.assert_not_awaited()
+    channel.send.assert_awaited_once_with(content=None, embed=overview_embed, view=overview_view)
+    assert result["id"] == "1A"
+
+
+@pytest.mark.asyncio
+async def test_single_problem_source_preserves_daily_problem_rendering(monkeypatch):
+    problem = _problem("1A", "A")
+    daily = {"date": "2026-06-09", "source": "sheep", "problems": [problem]}
+    bot, channel = _bot_with_daily(daily)
+    problem_embed = discord.Embed(title="A")
+    problem_view = MagicMock()
+    create_problem_embed = AsyncMock(return_value=problem_embed)
+    create_problem_view = AsyncMock(return_value=problem_view)
+    create_overview_embed = MagicMock()
+    monkeypatch.setattr(ui_helpers, "create_problem_embed", create_problem_embed)
+    monkeypatch.setattr(ui_helpers, "create_problem_view", create_problem_view)
+    monkeypatch.setattr(ui_helpers, "create_problems_overview_embed", create_overview_embed)
+
+    await send_daily_challenge(bot=bot, channel_id=123, daily_source="sheep", guild_locale="zh-TW")
+
+    create_problem_embed.assert_awaited_once()
+    create_problem_view.assert_awaited_once()
+    create_overview_embed.assert_not_called()
+    channel.send.assert_awaited_once_with(content=None, embed=problem_embed, view=problem_view)
+
+
+@pytest.mark.asyncio
+async def test_source_delivery_preserves_role_mention(monkeypatch):
+    problem = _problem("1A", "A")
+    daily = {"date": "2026-06-09", "source": "sheep", "problems": [problem]}
+    bot, channel = _bot_with_daily(daily)
+    role = SimpleNamespace(mention="<@&456>")
+    channel.guild.get_role.return_value = role
+    monkeypatch.setattr(ui_helpers, "create_problem_embed", AsyncMock(return_value=discord.Embed(title="A")))
+    monkeypatch.setattr(ui_helpers, "create_problem_view", AsyncMock(return_value=MagicMock()))
+
+    await send_daily_challenge(
+        bot=bot,
+        channel_id=123,
+        role_id=456,
+        daily_source="sheep",
+        guild_locale="zh-TW",
+    )
+
+    assert channel.send.await_args.kwargs["content"] == "<@&456>"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_source_delivery_propagates_not_found():
+    bot, _ = _bot_with_daily({})
+    bot.api.get_daily.side_effect = ApiDailyNotFoundError("0x3f")
+
+    with pytest.raises(ApiDailyNotFoundError, match="0x3f"):
+        await send_daily_challenge(bot=bot, channel_id=123, daily_source="0x3f", guild_locale="zh-TW")

--- a/tests/test_database_schema_assets.py
+++ b/tests/test_database_schema_assets.py
@@ -11,6 +11,7 @@ CLEANUP_SCHEMA_PATH = DATA_DIR / "cleanup_db_schema.sql"
 CLEANUP_RUNTIME_PATH = DATA_DIR / "cleanup_runtime_db.py"
 TARGET_TABLES = {
     "server_settings",
+    "daily_push_settings",
     "llm_translate_results",
     "llm_inspire_results",
 }
@@ -72,6 +73,36 @@ def test_init_db_schema_sql_creates_only_runtime_tables(tmp_path):
     _run_sql_script(db_path, _read_sql(INIT_SCHEMA_PATH))
 
     assert _get_user_tables(db_path) == TARGET_TABLES
+
+
+def test_init_db_schema_enforces_daily_push_source_and_identity(tmp_path):
+    db_path = tmp_path / "push-constraints.sqlite"
+    _run_sql_script(db_path, _read_sql(INIT_SCHEMA_PATH))
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("INSERT INTO server_settings (server_id) VALUES (1)")
+        for index, source in enumerate(("leetcode.com", "sheep", "0x3f"), start=1):
+            connection.execute(
+                "INSERT INTO daily_push_settings (server_id, source, channel_id) VALUES (?, ?, ?)",
+                (1, source, index),
+            )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "INSERT INTO daily_push_settings (server_id, source, channel_id) VALUES (1, 'sheep', 99)"
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "INSERT INTO daily_push_settings (server_id, source, channel_id) VALUES (1, 'unknown', 100)"
+            )
+
+        connection.execute("DELETE FROM server_settings WHERE server_id = 1")
+        remaining_pushes = connection.execute(
+            "SELECT COUNT(*) FROM daily_push_settings WHERE server_id = 1"
+        ).fetchone()[0]
+
+    assert remaining_pushes == 0
 
 
 def test_cleanup_db_schema_sql_removes_legacy_tables_and_is_idempotent(tmp_path):
@@ -158,3 +189,51 @@ def test_cleanup_runtime_db_rebuilds_legacy_llm_tables_with_source_alias(
         row = connection.execute(f"SELECT * FROM {table_name}").fetchone()
 
     assert row == expected_row
+
+
+def test_cleanup_runtime_db_converts_legacy_server_settings_to_leetcode_push(tmp_path, cleanup_runtime_module):
+    db_path = tmp_path / "legacy-settings.sqlite"
+    temp_db_path = tmp_path / "legacy-settings.cleanup-tmp.sqlite"
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE server_settings (
+                server_id INTEGER PRIMARY KEY,
+                channel_id INTEGER NOT NULL,
+                role_id INTEGER,
+                post_time TEXT DEFAULT '00:00',
+                timezone TEXT DEFAULT 'UTC',
+                language TEXT NOT NULL DEFAULT 'zh-TW',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO server_settings
+                (server_id, channel_id, role_id, post_time, timezone, language)
+            VALUES (123, 456, 789, '08:30', 'Asia/Taipei', 'en-US')
+            """
+        )
+
+    copied_tables = cleanup_runtime_module.rebuild_database(
+        db_path,
+        INIT_SCHEMA_PATH,
+        temp_db_path,
+    )
+
+    assert "server_settings" in copied_tables
+    assert "daily_push_settings" in copied_tables
+    with sqlite3.connect(temp_db_path) as connection:
+        guild_row = connection.execute("SELECT server_id, language FROM server_settings").fetchone()
+        push_row = connection.execute(
+            """
+            SELECT server_id, source, channel_id, role_id, post_time, timezone
+            FROM daily_push_settings
+            """
+        ).fetchone()
+
+    assert guild_row == (123, "en-US")
+    assert push_row == (123, "leetcode.com", 456, 789, "08:30", "Asia/Taipei")

--- a/tests/test_interaction_handler.py
+++ b/tests/test_interaction_handler.py
@@ -32,6 +32,8 @@ class TestInteractionHandler:
         bot.i18n = MagicMock()
         bot.i18n.t = MagicMock(side_effect=lambda key, locale, **kwargs: key.replace(".", "_"))
         bot.i18n.resolve_locale = MagicMock(return_value="zh-TW")
+        bot.db = MagicMock()
+        bot.reschedule_daily_challenge = AsyncMock()
         return bot
 
     @pytest.fixture
@@ -103,6 +105,109 @@ class TestInteractionHandler:
 
         # Cleanup non-existent request should not raise error
         await cog._cleanup_request(request_key)  # Should use discard, not remove
+
+    @pytest.mark.asyncio
+    async def test_config_remove_confirm_deletes_and_reschedules_only_selected_source(
+        self, cog, mock_bot, mock_interaction, monkeypatch
+    ):
+        monkeypatch.setattr(interaction_handler_module.time, "time", lambda: 100)
+        mock_bot.db.delete_daily_push.return_value = True
+        mock_interaction.user.guild_permissions.manage_guild = True
+        mock_interaction.data = {
+            "custom_id": "config_remove_confirm|987654321|123456789|200|sheep",
+        }
+
+        await cog.on_interaction(mock_interaction)
+
+        mock_bot.db.delete_daily_push.assert_called_once_with(987654321, "sheep")
+        mock_bot.db.delete_server_settings.assert_not_called()
+        mock_bot.reschedule_daily_challenge.assert_awaited_once_with(
+            987654321,
+            "config_remove",
+            source="sheep",
+        )
+        mock_interaction.response.edit_message.assert_awaited_once_with(
+            content="errors_remove_success",
+            embed=None,
+            view=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_config_remove_cancel_does_not_delete(self, cog, mock_bot, mock_interaction, monkeypatch):
+        monkeypatch.setattr(interaction_handler_module.time, "time", lambda: 100)
+        mock_interaction.data = {
+            "custom_id": "config_remove_cancel|987654321|123456789|200|0x3f",
+        }
+
+        await cog.on_interaction(mock_interaction)
+
+        mock_bot.db.delete_daily_push.assert_not_called()
+        mock_bot.reschedule_daily_challenge.assert_not_awaited()
+        mock_interaction.response.edit_message.assert_awaited_once_with(
+            content="errors_remove_cancelled",
+            embed=None,
+            view=None,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("custom_id", "expected_message"),
+        [
+            ("config_remove_confirm|987654321|123456789|200", "errors_remove_invalid_action"),
+            ("config_remove_confirm|bad|123456789|200|sheep", "errors_remove_invalid_action"),
+            ("config_remove_confirm|987654321|123456789|200|unknown", "errors_remove_invalid_action"),
+            ("config_remove_confirm|111|123456789|200|sheep", "errors_remove_invalid_action"),
+            ("config_remove_confirm|987654321|111|200|sheep", "errors_remove_wrong_user"),
+            ("config_remove_confirm|987654321|123456789|99|sheep", "errors_remove_expired"),
+        ],
+    )
+    async def test_config_remove_rejects_invalid_context(
+        self,
+        cog,
+        mock_bot,
+        mock_interaction,
+        monkeypatch,
+        custom_id,
+        expected_message,
+    ):
+        monkeypatch.setattr(interaction_handler_module.time, "time", lambda: 100)
+        mock_interaction.data = {"custom_id": custom_id}
+
+        await cog.on_interaction(mock_interaction)
+
+        mock_interaction.response.send_message.assert_awaited_once_with(expected_message, ephemeral=True)
+        mock_bot.db.delete_daily_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_remove_requires_manage_guild_permission(self, cog, mock_bot, mock_interaction, monkeypatch):
+        monkeypatch.setattr(interaction_handler_module.time, "time", lambda: 100)
+        mock_interaction.user.guild_permissions.manage_guild = False
+        mock_interaction.data = {
+            "custom_id": "config_remove_confirm|987654321|123456789|200|leetcode.com",
+        }
+
+        await cog.on_interaction(mock_interaction)
+
+        mock_interaction.response.send_message.assert_awaited_once_with(
+            "errors_remove_permission_denied",
+            ephemeral=True,
+        )
+        mock_bot.db.delete_daily_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_config_reset_routing_remains_whole_guild(self, cog, mock_bot, mock_interaction, monkeypatch):
+        monkeypatch.setattr(interaction_handler_module.time, "time", lambda: 100)
+        mock_bot.db.delete_server_settings.return_value = True
+        mock_interaction.user.guild_permissions.manage_guild = True
+        mock_interaction.data = {
+            "custom_id": "config_reset_confirm|987654321|123456789|200",
+        }
+
+        await cog.on_interaction(mock_interaction)
+
+        mock_bot.db.delete_server_settings.assert_called_once_with(987654321)
+        mock_bot.db.delete_daily_push.assert_not_called()
+        mock_bot.reschedule_daily_challenge.assert_awaited_once_with(987654321, "config_reset")
 
     @pytest.mark.asyncio
     async def test_concurrent_requests_atomic(self, cog, mock_interaction):

--- a/tests/test_schedule_manager_cog.py
+++ b/tests/test_schedule_manager_cog.py
@@ -1,14 +1,28 @@
 import asyncio
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 import pytz
 from discord.ext import commands
 
+from bot.api_client import ApiDailyNotFoundError, ApiProcessingError
+from bot.app import _create_reschedule_helper
 from bot.cogs import schedule_manager_cog as schedule_module
 from bot.cogs.schedule_manager_cog import ScheduleManagerCog
+
+
+def _push(source: str, *, channel_id: int = 456, post_time: str = "09:30") -> dict:
+    return {
+        "server_id": 123,
+        "source": source,
+        "channel_id": channel_id,
+        "role_id": 789,
+        "post_time": post_time,
+        "timezone": "UTC",
+        "language": "zh-TW",
+    }
 
 
 def _make_bot():
@@ -16,6 +30,8 @@ def _make_bot():
     bot.config = SimpleNamespace(default_locale="zh-TW")
     bot.i18n = MagicMock()
     bot.i18n.resolve_locale = MagicMock(return_value="zh-TW")
+    bot.db = MagicMock()
+    bot.logger = MagicMock()
     return bot
 
 
@@ -28,28 +44,59 @@ def test_scheduler_job_defaults_prevent_overlapping_daily_jobs():
 
 
 @pytest.mark.asyncio
-async def test_add_server_schedule_keeps_misfire_grace_time(monkeypatch):
+async def test_initialize_schedules_creates_one_job_per_push(monkeypatch):
+    bot = _make_bot()
+    bot.db.get_all_daily_pushes.return_value = [_push("leetcode.com"), _push("sheep"), _push("0x3f")]
+    cog = ScheduleManagerCog(bot)
+    monkeypatch.setattr(cog.scheduler, "start", MagicMock())
+    monkeypatch.setattr(cog.scheduler, "remove_all_jobs", MagicMock())
+    monkeypatch.setattr(cog.scheduler, "get_job", MagicMock(return_value=None))
+    add_job = MagicMock()
+    monkeypatch.setattr(cog.scheduler, "add_job", add_job)
+
+    await cog.initialize_schedules()
+
+    assert [item.kwargs["id"] for item in add_job.call_args_list] == [
+        "daily_challenge:123:leetcode.com",
+        "daily_challenge:123:sheep",
+        "daily_challenge:123:0x3f",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_add_server_schedule_keeps_source_identity_and_misfire_grace_time(monkeypatch):
     cog = ScheduleManagerCog(_make_bot())
     add_job = MagicMock()
     monkeypatch.setattr(cog.scheduler, "add_job", add_job)
     monkeypatch.setattr(cog.scheduler, "get_job", MagicMock(return_value=None))
 
-    await cog.add_server_schedule(
-        {
-            "server_id": 123,
-            "channel_id": 456,
-            "role_id": 789,
-            "post_time": "09:30",
-            "timezone": "UTC",
-        }
-    )
+    await cog.add_server_schedule(_push("sheep"))
 
-    assert add_job.call_args.kwargs["misfire_grace_time"] == 300
-    assert add_job.call_args.kwargs["id"] == "daily_challenge_123"
+    kwargs = add_job.call_args.kwargs
+    assert kwargs["misfire_grace_time"] == 300
+    assert kwargs["id"] == "daily_challenge:123:sheep"
+    assert kwargs["args"] == [123, "sheep", 456, 789, "UTC"]
 
 
 @pytest.mark.asyncio
-async def test_duplicate_scheduled_delivery_is_skipped(monkeypatch):
+async def test_invalid_push_does_not_prevent_peer_source_schedule(monkeypatch):
+    bot = _make_bot()
+    bot.db.get_all_daily_pushes.return_value = [_push("sheep", post_time="bad"), _push("0x3f")]
+    cog = ScheduleManagerCog(bot)
+    monkeypatch.setattr(cog.scheduler, "start", MagicMock())
+    monkeypatch.setattr(cog.scheduler, "remove_all_jobs", MagicMock())
+    monkeypatch.setattr(cog.scheduler, "get_job", MagicMock(return_value=None))
+    add_job = MagicMock()
+    monkeypatch.setattr(cog.scheduler, "add_job", add_job)
+
+    await cog.initialize_schedules()
+
+    add_job.assert_called_once()
+    assert add_job.call_args.kwargs["id"] == "daily_challenge:123:0x3f"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_scheduled_delivery_is_skipped_per_source(monkeypatch):
     cog = ScheduleManagerCog(_make_bot())
     release = asyncio.Event()
     send_calls = 0
@@ -62,20 +109,21 @@ async def test_duplicate_scheduled_delivery_is_skipped(monkeypatch):
 
     monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
 
-    first = asyncio.create_task(cog.send_daily_challenge_job(123, 456, 789))
+    first = asyncio.create_task(cog.send_daily_challenge_job(123, "sheep", 456, 789))
     await asyncio.sleep(0)
-    second = asyncio.create_task(cog.send_daily_challenge_job(123, 456, 789))
+    duplicate = asyncio.create_task(cog.send_daily_challenge_job(123, "sheep", 456, 789))
+    peer_source = asyncio.create_task(cog.send_daily_challenge_job(123, "0x3f", 456, 789))
     await asyncio.sleep(0)
     release.set()
 
-    await asyncio.gather(first, second)
+    await asyncio.gather(first, duplicate, peer_source)
 
-    assert send_calls == 1
+    assert send_calls == 2
     assert cog.scheduled_deliveries_in_progress == set()
 
 
 @pytest.mark.asyncio
-async def test_scheduled_delivery_uses_current_daily_request(monkeypatch):
+async def test_scheduled_delivery_forwards_source_and_uses_source_guard(monkeypatch):
     cog = ScheduleManagerCog(_make_bot())
     fixed_utc = datetime(2026, 6, 2, 16, tzinfo=pytz.UTC)
     sent_kwargs = None
@@ -83,29 +131,104 @@ async def test_scheduled_delivery_uses_current_daily_request(monkeypatch):
     async def send_daily_challenge(**kwargs):
         nonlocal sent_kwargs
         sent_kwargs = kwargs
-        assert cog.scheduled_deliveries_in_progress == {(123, 456, "com", "2026-06-03")}
+        assert cog.scheduled_deliveries_in_progress == {(123, 456, "sheep", "2026-06-03")}
         return {"title": "Two Sum"}
 
     monkeypatch.setattr(schedule_module, "datetime", SimpleNamespace(now=lambda tz=None: fixed_utc.astimezone(tz)))
     monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
 
-    await cog.send_daily_challenge_job(123, 456, 789, "Asia/Taipei")
+    await cog.send_daily_challenge_job(123, "sheep", 456, 789, "Asia/Taipei")
 
+    assert sent_kwargs["daily_source"] == "sheep"
     assert "date_str" not in sent_kwargs
+
+
+@pytest.mark.asyncio
+async def test_scheduled_source_not_found_is_expected_skip(monkeypatch):
+    cog = ScheduleManagerCog(_make_bot())
+    send = AsyncMock(side_effect=ApiDailyNotFoundError("0x3f"))
+    monkeypatch.setattr(schedule_module, "send_daily_challenge", send)
+
+    await cog.send_daily_challenge_job(123, "0x3f", 456)
+
+    send.assert_awaited_once()
+    assert cog.scheduled_deliveries_in_progress == set()
+
+
+@pytest.mark.asyncio
+async def test_processing_response_retries_source_delivery(monkeypatch):
+    cog = ScheduleManagerCog(_make_bot())
+    send = AsyncMock(side_effect=[ApiProcessingError(), {"title": "Two Sum"}])
+    sleep = AsyncMock()
+    monkeypatch.setattr(schedule_module, "send_daily_challenge", send)
+    monkeypatch.setattr(schedule_module.asyncio, "sleep", sleep)
+    monkeypatch.setattr(schedule_module.random, "uniform", lambda *_args: 0)
+
+    await cog.send_daily_challenge_job(123, "sheep", 456)
+
+    assert send.await_count == 2
+    assert all(item.kwargs["daily_source"] == "sheep" for item in send.await_args_list)
+    sleep.assert_awaited_once_with(2)
 
 
 @pytest.mark.asyncio
 async def test_scheduled_delivery_guard_cleans_up_after_exception(monkeypatch):
     cog = ScheduleManagerCog(_make_bot())
+    send = AsyncMock(side_effect=RuntimeError("discord send failed"))
+    monkeypatch.setattr(schedule_module, "send_daily_challenge", send)
 
-    async def send_daily_challenge(**kwargs):
-        raise RuntimeError("discord send failed")
+    await cog.send_daily_challenge_job(123, "leetcode.com", 456, 789)
+    await cog.send_daily_challenge_job(123, "leetcode.com", 456, 789)
 
-    monkeypatch.setattr(schedule_module, "send_daily_challenge", send_daily_challenge)
-
-    await cog.send_daily_challenge_job(123, 456, 789)
-
+    assert send.await_count == 2
     assert cog.scheduled_deliveries_in_progress == set()
 
-    await cog.send_daily_challenge_job(123, 456, 789)
-    assert cog.scheduled_deliveries_in_progress == set()
+
+@pytest.mark.asyncio
+async def test_targeted_source_removal_preserves_peer_jobs(monkeypatch):
+    bot = _make_bot()
+    bot.db.get_daily_push.return_value = None
+    cog = ScheduleManagerCog(bot)
+    get_job = MagicMock(return_value=object())
+    remove_job = MagicMock()
+    monkeypatch.setattr(cog.scheduler, "get_job", get_job)
+    monkeypatch.setattr(cog.scheduler, "remove_job", remove_job)
+
+    await cog.reschedule_daily_challenge(123, "sheep")
+
+    get_job.assert_called_once_with("daily_challenge:123:sheep")
+    remove_job.assert_called_once_with("daily_challenge:123:sheep")
+    bot.db.get_daily_push.assert_called_once_with(123, "sheep")
+
+
+@pytest.mark.asyncio
+async def test_server_reschedule_rebuilds_all_source_jobs(monkeypatch):
+    bot = _make_bot()
+    bot.db.get_daily_pushes.return_value = [_push("leetcode.com"), _push("0x3f")]
+    cog = ScheduleManagerCog(bot)
+    monkeypatch.setattr(cog.scheduler, "get_job", MagicMock(return_value=object()))
+    remove_job = MagicMock()
+    monkeypatch.setattr(cog.scheduler, "remove_job", remove_job)
+    add_schedule = AsyncMock()
+    monkeypatch.setattr(cog, "add_server_schedule", add_schedule)
+
+    await cog.reschedule_daily_challenge(123)
+
+    assert remove_job.call_args_list == [
+        call("daily_challenge:123:leetcode.com"),
+        call("daily_challenge:123:sheep"),
+        call("daily_challenge:123:0x3f"),
+    ]
+    assert [item.args[0]["source"] for item in add_schedule.await_args_list] == ["leetcode.com", "0x3f"]
+
+
+@pytest.mark.asyncio
+async def test_app_reschedule_helper_forwards_optional_source():
+    bot = _make_bot()
+    schedule_cog = SimpleNamespace(reschedule_daily_challenge=AsyncMock())
+    bot.get_cog.return_value = schedule_cog
+    helper = _create_reschedule_helper(bot)
+
+    await helper(123, "config_update", source="sheep")
+
+    schedule_cog.reschedule_daily_challenge.assert_awaited_once_with(123, "sheep")

--- a/tests/test_settings_database.py
+++ b/tests/test_settings_database.py
@@ -1,0 +1,192 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from bot.utils.database import SettingsDatabaseManager
+
+
+def _create_legacy_database(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE server_settings (
+                server_id INTEGER PRIMARY KEY,
+                channel_id INTEGER NOT NULL,
+                role_id INTEGER,
+                post_time TEXT DEFAULT '00:00',
+                timezone TEXT DEFAULT 'UTC',
+                language TEXT NOT NULL DEFAULT 'zh-TW',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO server_settings
+                (server_id, channel_id, role_id, post_time, timezone, language)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, 101, 201, "08:00", "Asia/Taipei", "zh-TW"),
+                (2, 102, None, "09:30", "UTC+8", "en-US"),
+            ],
+        )
+
+
+def _table_columns(db_path: Path, table_name: str) -> set[str]:
+    with sqlite3.connect(db_path) as connection:
+        return {row[1] for row in connection.execute(f'PRAGMA table_info("{table_name}")')}
+
+
+def test_daily_push_crud_is_independent_per_source(tmp_path):
+    manager = SettingsDatabaseManager(tmp_path / "settings.sqlite")
+
+    assert manager.set_daily_push(1, "leetcode.com", 101, 201, "08:00", "Asia/Taipei")
+    assert manager.set_daily_push(1, "sheep", 102, None, "09:00", "UTC")
+    assert manager.set_daily_push(1, "0x3f", 103, 203, "10:00", "UTC+8")
+    assert manager.set_daily_push(1, "sheep", 202, 302, "11:00", "Asia/Tokyo")
+
+    pushes = manager.get_daily_pushes(1)
+
+    assert [push["source"] for push in pushes] == ["leetcode.com", "sheep", "0x3f"]
+    assert manager.get_daily_push(1, "leetcode.com")["channel_id"] == 101
+    assert manager.get_daily_push(1, "0x3f")["channel_id"] == 103
+    assert manager.get_daily_push(1, "sheep") == {
+        "server_id": 1,
+        "source": "sheep",
+        "channel_id": 202,
+        "role_id": 302,
+        "post_time": "11:00",
+        "timezone": "Asia/Tokyo",
+    }
+
+
+def test_daily_push_creation_ensures_default_guild_language(tmp_path):
+    manager = SettingsDatabaseManager(tmp_path / "settings.sqlite")
+
+    assert manager.set_daily_push(7, "sheep", 700)
+
+    assert manager.get_server_settings(7) == {"server_id": 7, "language": "zh-TW"}
+    assert manager.set_server_language(7, "en-US")
+    assert manager.get_server_settings(7) == {"server_id": 7, "language": "en-US"}
+    assert manager.get_daily_push(7, "sheep")["channel_id"] == 700
+
+
+def test_daily_push_rejects_unsupported_source(tmp_path):
+    manager = SettingsDatabaseManager(tmp_path / "settings.sqlite")
+
+    with pytest.raises(ValueError, match="Unsupported daily push source"):
+        manager.set_daily_push(1, "unknown", 100)
+
+
+def test_delete_daily_push_and_server_reset_are_scoped(tmp_path):
+    manager = SettingsDatabaseManager(tmp_path / "settings.sqlite")
+    manager.set_daily_push(1, "leetcode.com", 101)
+    manager.set_daily_push(1, "sheep", 102)
+
+    assert manager.delete_daily_push(1, "sheep")
+    assert manager.get_daily_push(1, "sheep") is None
+    assert manager.get_daily_push(1, "leetcode.com") is not None
+    assert manager.get_server_settings(1) is not None
+
+    assert manager.delete_server_settings(1)
+    assert manager.get_server_settings(1) is None
+    assert manager.get_daily_pushes(1) == []
+
+
+def test_get_all_daily_pushes_includes_joined_language(tmp_path):
+    manager = SettingsDatabaseManager(tmp_path / "settings.sqlite")
+    manager.set_server_language(1, "en-US")
+    manager.set_daily_push(1, "leetcode.com", 101)
+    manager.set_daily_push(2, "sheep", 202)
+
+    assert manager.get_all_daily_pushes() == [
+        {
+            "server_id": 1,
+            "source": "leetcode.com",
+            "channel_id": 101,
+            "role_id": None,
+            "post_time": "00:00",
+            "timezone": "UTC",
+            "language": "en-US",
+        },
+        {
+            "server_id": 2,
+            "source": "sheep",
+            "channel_id": 202,
+            "role_id": None,
+            "post_time": "00:00",
+            "timezone": "UTC",
+            "language": "zh-TW",
+        },
+    ]
+
+
+def test_legacy_database_is_backed_up_and_migrated(tmp_path):
+    db_path = tmp_path / "legacy.sqlite"
+    _create_legacy_database(db_path)
+
+    manager = SettingsDatabaseManager(db_path)
+
+    backups = list(tmp_path.glob("legacy.sqlite.*.pre-push-redesign.bak"))
+    assert len(backups) == 1
+    assert _table_columns(db_path, "server_settings") == {
+        "server_id",
+        "language",
+        "created_at",
+        "updated_at",
+    }
+    assert "daily_push_settings" in {
+        row[0] for row in sqlite3.connect(db_path).execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    assert manager.get_server_settings(2) == {"server_id": 2, "language": "en-US"}
+    assert manager.get_daily_push(1, "leetcode.com") == {
+        "server_id": 1,
+        "source": "leetcode.com",
+        "channel_id": 101,
+        "role_id": 201,
+        "post_time": "08:00",
+        "timezone": "Asia/Taipei",
+    }
+    assert manager.get_daily_push(2, "leetcode.com")["channel_id"] == 102
+
+    with sqlite3.connect(backups[0]) as backup:
+        assert backup.execute("SELECT COUNT(*) FROM server_settings").fetchone()[0] == 2
+        assert "channel_id" in {row[1] for row in backup.execute("PRAGMA table_info(server_settings)")}
+
+
+def test_normalized_database_startup_is_idempotent(tmp_path):
+    db_path = tmp_path / "settings.sqlite"
+    manager = SettingsDatabaseManager(db_path)
+    manager.set_daily_push(1, "sheep", 101)
+
+    SettingsDatabaseManager(db_path)
+
+    assert list(tmp_path.glob("settings.sqlite.*.pre-push-redesign.bak")) == []
+    assert manager.get_daily_push(1, "sheep")["channel_id"] == 101
+
+
+def test_legacy_migration_validation_failure_rolls_back(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy.sqlite"
+    _create_legacy_database(db_path)
+
+    def fail_validation(self, connection, expected_count):
+        raise RuntimeError("injected migration validation failure")
+
+    monkeypatch.setattr(SettingsDatabaseManager, "_validate_legacy_migration", fail_validation)
+
+    with pytest.raises(RuntimeError, match="injected migration validation failure"):
+        SettingsDatabaseManager(db_path)
+
+    assert "channel_id" in _table_columns(db_path, "server_settings")
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM server_settings").fetchone()[0] == 2
+        assert (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'daily_push_settings'"
+            ).fetchone()
+            is None
+        )
+    assert len(list(tmp_path.glob("legacy.sqlite.*.pre-push-redesign.bak"))) == 1

--- a/tests/test_source_layout_phase12.py
+++ b/tests/test_source_layout_phase12.py
@@ -44,6 +44,7 @@ def test_database_manager_resolves_relative_path_from_repo_root(monkeypatch, tmp
     from bot.utils.database import SettingsDatabaseManager
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(SettingsDatabaseManager, "_init_db", lambda self: None)
 
     manager = SettingsDatabaseManager(db_path="data/test-settings.db")
 

--- a/tests/test_source_layout_phase56.py
+++ b/tests/test_source_layout_phase56.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -12,6 +13,7 @@ PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 README_PATH = REPO_ROOT / "README.md"
 CLAUDE_PATH = REPO_ROOT / "CLAUDE.md"
 TESTS_ROOT = REPO_ROOT / "tests"
+LOCALES_ROOT = REPO_ROOT / "src" / "bot" / "i18n" / "locales"
 
 
 def _read_text(path: Path) -> str:
@@ -68,3 +70,43 @@ def test_claude_md_matches_packaged_runtime_contract():
     assert "embedding_cli.py" not in claude_md
     assert "embeddings/" not in claude_md
     assert "migrate_embeddings.sql" not in claude_md
+
+
+def test_daily_push_redesign_keys_exist_in_every_supported_locale():
+    required_keys = (
+        "errors.config.source_invalid",
+        "errors.config.remove_conflict",
+        "errors.config.remove_source_required",
+        "errors.config.source_not_configured",
+        "errors.config.remove_confirm_message",
+        "errors.remove.invalid_action",
+        "errors.remove.wrong_user",
+        "errors.remove.expired",
+        "errors.remove.cancelled",
+        "errors.remove.permission_denied",
+        "errors.remove.error",
+        "errors.remove.success",
+        "ui.buttons.confirm_remove",
+        "ui.settings.no_pushes",
+        "commands.config.source",
+        "commands.config.remove",
+    )
+
+    for locale in ("zh-TW", "en-US", "zh-CN"):
+        data = json.loads(_read_text(LOCALES_ROOT / f"{locale}.json"))
+        for dotted_key in required_keys:
+            value = data
+            for part in dotted_key.split("."):
+                value = value[part]
+            assert isinstance(value, str) and value.strip(), f"{locale}: {dotted_key}"
+
+
+def test_readme_documents_independent_daily_sources_and_legacy_migration():
+    readme = _read_text(README_PATH)
+
+    assert "leetcode.com`, `sheep`, and `0x3f" in readme
+    assert "up to three independent daily pushes" in readme
+    assert "/config source:sheep channel:#sheep-daily" in readme
+    assert "/config source:0x3f remove:true" in readme
+    assert ".pre-push-redesign.bak" in readme
+    assert "migrated to the `leetcode.com` source" in readme


### PR DESCRIPTION
## Summary

- normalize guild language and source-specific push settings, including a timestamped transactional migration of legacy schedules to `leetcode.com`
- add independent API rendering, scheduler jobs, delivery guards, configuration, and confirmed removal for `leetcode.com`, `sheep`, and `0x3f`
- preserve source-less LeetCode configuration, manual domain daily calls, legacy reset IDs, locale parity, and operator migration documentation

## Test plan

- [x] `uv run pytest tests/test_settings_database.py tests/test_database_schema_assets.py tests/test_bootstrap_and_paths.py tests/test_daily_source_delivery.py tests/test_daily_payload_reuse.py tests/test_schedule_manager_cog.py tests/test_config_command.py tests/test_interaction_handler.py tests/test_source_layout_phase56.py`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `openspec validate redesign-daily-push-mechanism --strict`
- [x] `python3 /home/usaya/.codex/aegis/scripts/aegis-workspace.py check --root .`

## Residual validation

- live Discord delivery, live upstream source responses, and a production database migration were not executed in this workspace